### PR TITLE
Fix datetime comparison in check for sendtime in the past

### DIFF
--- a/test/miscellaneoustests.js
+++ b/test/miscellaneoustests.js
@@ -20,26 +20,55 @@ exports.init = function() {
     return (result === expected) || `Expected "${expected}", got "${result}"`;
   }, [ "Sun Feb 01 1998 15:03:00 GMT+2", "Sun, Feb 1, 1998, 13:03:00" ]);
 
-  function TestCompareTimes(a,comparison,b,expected) {
+  function TestComparison(func,a,comparison,b,ignoreSec,expected) {
     a = new Date(a), b = new Date(b);
-    const result = SLStatic.compareTimes(a,comparison,b);
+    const result = func(a,comparison,b,ignoreSec);
     return (result === expected) || `Expected "${expected}", got "${result}"`;
   }
 
-  SLTests.AddTest("Test compareTimes a < b", TestCompareTimes, [
-    "8/31/2020, 05:00:00 AM", "<", "8/30/2020, 07:00:00 AM", true
+  SLTests.AddTest("Test compareTimes a < b", TestComparison, [
+    SLStatic.compareTimes,
+    "8/31/2020, 05:00:00 AM", "<", "8/30/2020, 07:00:00 AM", false, true
   ]);
-  SLTests.AddTest("Test compareTimes a >= b", TestCompareTimes, [
-    "8/31/2020, 05:00:00 AM", "<=", "8/30/2020, 05:00:00 AM", true
+  SLTests.AddTest("Test compareTimes a >= b", TestComparison, [
+    SLStatic.compareTimes,
+    "8/31/2020, 05:00:00 AM", "<=", "8/30/2020, 05:00:00 AM", false, true
   ]);
-  SLTests.AddTest("Test compareTimes a > b", TestCompareTimes, [
-    "8/31/2020, 05:15:00 PM", ">", "8/30/2020, 05:00:00 AM", true
+  SLTests.AddTest("Test compareTimes a > b", TestComparison, [
+    SLStatic.compareTimes,
+    "8/31/2020, 05:15:00 PM", ">", "8/30/2020, 05:00:00 AM", false, true
   ]);
-  SLTests.AddTest("Test compareTimes a >= b", TestCompareTimes, [
-    "8/31/2020, 05:15:00 PM", ">=", "8/30/2020, 05:15:00 AM", true
+  SLTests.AddTest("Test compareTimes a >= b", TestComparison, [
+    SLStatic.compareTimes,
+    "8/31/2020, 05:15:00 PM", ">=", "8/30/2020, 05:15:00 AM", false, true
   ]);
-  SLTests.AddTest("Test compareTimes a === b", TestCompareTimes, [
-    "8/31/2019, 05:01:00 PM", "===", "8/30/2020, 05:01:00 PM", true
+  SLTests.AddTest("Test compareTimes a === b", TestComparison, [
+    SLStatic.compareTimes,
+    "8/31/2019, 05:01:00 PM", "===", "8/30/2020, 05:01:00 PM", false, true
+  ]);
+  SLTests.AddTest("Test compareDates a < b differentmonth", TestComparison, [
+    SLStatic.compareDates,
+    "7/31/2020, 09:01:00 AM", "<", "8/01/2020, 05:01:00 AM", null, true
+  ]);
+  SLTests.AddTest("Test compareDates ! a == b false", TestComparison, [
+    SLStatic.compareDates,
+    "7/31/2020, 09:01:00 AM", "==", "8/01/2020, 05:01:00 AM", null, false
+  ]);
+  SLTests.AddTest("Test compareDates a == b false", TestComparison, [
+    SLStatic.compareDates,
+    "7/31/2020, 09:01:00 AM", "==", "7/31/2020, 05:01:00 AM", null, true
+  ]);
+  SLTests.AddTest("Test compareDateTimes a === b !ignoreSec", TestComparison, [
+    SLStatic.compareDateTimes,
+    "7/31/2020, 09:00:00 AM", "===", "7/31/2020, 09:00:20 AM", false, false
+  ]);
+  SLTests.AddTest("Test compareDateTimes a === b ignoreSec", TestComparison, [
+    SLStatic.compareDateTimes,
+    "7/31/2020, 09:00:00 AM", "===", "7/31/2020, 09:00:20 AM", true, true
+  ]);
+  SLTests.AddTest("Test compareDateTimes a < b differentmonth", TestComparison, [
+    SLStatic.compareDateTimes,
+    "7/31/2020, 09:01:00 AM", "<", "8/01/2020, 05:01:00 AM", false, true
   ]);
 
   SLTests.AddTest("Test parseDateTime", (dstr,tstr,expected) => {

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -128,7 +128,7 @@ const SLPopup = {
         let argStr = inputs["recur-function-args"];
         const schedule = await SLPopup.evaluateUfunc(funcName, argStr);
         schedule.recur.cancelOnReply = inputs[`recur-cancelonreply`];
-        if (SLStatic.compareTimes(schedule.sendAt, '<', new Date(), true)) {
+        if (SLStatic.compareDateTimes(schedule.sendAt, '<', new Date(), true)) {
           return { err: browser.i18n.getMessage("errorDateInPast") };
         }
         return schedule;
@@ -144,7 +144,7 @@ const SLPopup = {
       return { err: browser.i18n.getMessage("entervalid") };
     }
     const sendAt = SLStatic.parseDateTime(sendAtDate, sendAtTime);
-    if (SLStatic.compareTimes(sendAt, '<', new Date(), true)) {
+    if (SLStatic.compareDateTimes(sendAt, '<', new Date(), true)) {
       return { err: browser.i18n.getMessage("errorDateInPast") };
     }
 

--- a/utils/static.js
+++ b/utils/static.js
@@ -46,34 +46,52 @@ const SLStatic = {
     return fm.format(thisdate || (new Date()));
   },
 
-  compareTimes: function(a,comparison,b,ignoreSec) {
-    // Compare time of day, ignoring date.
-    const aHrs = a.getHours(), aMins = a.getMinutes();
-    const bHrs = b.getHours(), bMins = b.getMinutes();
-    const aSec = a.getSeconds(), bSec = b.getSeconds();
+  compare: function (a, comparison, b) {
     switch (comparison) {
       case "<":
-        return ((aHrs<bHrs) || (aHrs === bHrs && aMins<bMins) ||
-                (!ignoreSec && aHrs === bHrs && aMins === bMins && aSec < bSec));
+        return (a < b);
       case ">":
-        return ((aHrs>bHrs) || (aHrs === bHrs && aMins>bMins) ||
-                (!ignoreSec && aHrs === bHrs && aMins === bMins && aSec > bSec));
+        return (a > b);
       case "<=":
-        return ((aHrs<bHrs) || (aHrs === bHrs && aMins<=bMins) ||
-                (!ignoreSec && aHrs === bHrs && aMins === bMins && aSec <= bSec));
+        return (a <= b);
       case ">=":
-        return ((aHrs>bHrs) || (aHrs === bHrs && aMins>=bMins) ||
-                (!ignoreSec && aHrs === bHrs && aMins === bMins && aSec >= bSec));
+        return (a >= b);
       case "==":
+        return (a == b);
       case "===":
-        return (aHrs === bHrs && aMins === bMins && (ignoreSec || aSec === bSec));
+        return (a === b);
       case "!=":
+        return (a != b);
       case "!==":
-        return !SLStatic.compareTimes(a,"===",b);
+        return (a !== b);
       default:
         throw new Error("Unknown comparison: "+comparison);
         break;
     }
+  },
+
+  compareDates: function(a,comparison,b) {
+    const A = new Date(a.getFullYear(), a.getMonth(), a.getDate());
+    const B = new Date(b.getFullYear(), b.getMonth(), b.getDate());
+    return SLStatic.compare(A.getTime(),comparison,B.getTime());
+  },
+
+  compareTimes: function(a,comparison,b,ignoreSec) {
+    const A = new Date(2000, 0, 01, a.getHours(), a.getMinutes(),
+                        (ignoreSec ? 0 : a.getSeconds()));
+    const B = new Date(2000, 0, 01, b.getHours(), b.getMinutes(),
+                        (ignoreSec ? 0 : b.getSeconds()));
+    return SLStatic.compare(A.getTime(),comparison,B.getTime());
+  },
+
+  compareDateTimes: function(a, comparison, b, ignoreSec) {
+    const A = new Date(a.getTime());
+    const B = new Date(b.getTime());
+    if (ignoreSec) {
+      A.setSeconds(0);
+      B.setSeconds(0);
+    }
+    return SLStatic.compare(A.getTime(), comparison, B.getTime());
   },
 
   getWkdayName: function(i, style) {


### PR DESCRIPTION
Should fix bug reported in https://github.com/Extended-Thunder/send-later/issues/7#issuecomment-667156933 where only the time field is compared when checking whether scheduled send is in the past.