### PR TITLE
Use ISO-8601 formatting for datetime strings that will later be parsed back into Date objects

### DIFF
--- a/test/miscellaneoustests.js
+++ b/test/miscellaneoustests.js
@@ -1,3 +1,5 @@
+var moment = require('../utils/moment.min.js');
+
 exports.init = function() {
   // Example
   SLTests.AddTest("Test name", (input, expected) => {
@@ -12,13 +14,11 @@ exports.init = function() {
   }, [ [[2,3,4,1],[1,5,2],[1],[44,4],[7]],
        [2,3,4,1,1,5,2,1,44,4,7] ]);
 
-  SLTests.AddTest("Test dateTimeFormat", (input, expected) => {
-    opts = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric',
-      hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'UTC',
-      hour12: false };
-    const result = SLStatic.dateTimeFormat(new Date(input),opts);
-    return (result === expected) || `Expected "${expected}", got "${result}"`;
-  }, [ "Sun Feb 01 1998 15:03:00 GMT+2", "Sun, Feb 1, 1998, 13:03:00" ]);
+  SLTests.AddTest("Test parseableDateTimeFormat", (input, expected) => {
+    const result = SLStatic.parseableDateTimeFormat(new Date(input));
+    return moment(result, 'YYYY-MM-DDTHH:mm:ssZ', true).isSame(expected) ||
+          `Expected "${expected}", got "${result}"`;
+  }, [ "Sun Feb 01 1998 15:03:00 GMT+2", "Sun, 01 Feb 1998 13:03:00 GMT" ]);
 
   function TestComparison(func,a,comparison,b,ignoreSec,expected) {
     a = new Date(a), b = new Date(b);

--- a/utils/static.js
+++ b/utils/static.js
@@ -30,20 +30,12 @@ const SLStatic = {
                       ), []);
   },
 
-  dateTimeFormat: function(thisdate, opts, locale) {
-    const defaults = {
-      weekday: 'short',
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZoneName: 'short',
-      hour12: false
-    };
-    const fm = new Intl.DateTimeFormat((locale || 'en-GB'), (opts || defaults));
-    return fm.format(thisdate || (new Date()));
+  parseableDateTimeFormat: function(date) {
+    return moment(date || (new Date())).format();
+  },
+
+  humanDateTimeFormat: function(date) {
+    return moment(date).format('LLL');
   },
 
   compare: function (a, comparison, b) {
@@ -101,6 +93,7 @@ const SLStatic = {
   },
 
   parseDateTime: function(dstr,tstr) {
+    // Inputs: dstr (formatted YYYY/MM/DD), tstr (formatted HH:MM)
     const dpts = dstr ? dstr.split(/\D/) : [0,1,0];
     const tpts = SLStatic.timeRegex.test(tstr) ?
                     SLStatic.timeRegex.exec(tstr) : [null, 0, 0];
@@ -188,7 +181,8 @@ const SLStatic = {
                                               [recurSpec.function]);
     } else {
       scheduleText = browser.i18n.getMessage("sendAtLabel");
-      scheduleText += " " + SLStatic.dateTimeFormat(sendAt);
+      scheduleText += " " + SLStatic.humanDateTimeFormat(sendAt);
+      scheduleText += ` (${moment(sendAt).fromNow()})`;
     }
 
     if (recur.type  !== "none") {
@@ -222,7 +216,7 @@ const SLStatic = {
   },
 
   prepNewMessageHeaders: function(content) {
-    content = SLStatic.replaceHeader(content, "Date", SLStatic.dateTimeFormat());
+    content = SLStatic.replaceHeader(content, "Date", SLStatic.parseableDateTimeFormat());
     content = SLStatic.replaceHeader(content, "X-Send-Later-.*");
     content = SLStatic.replaceHeader(content, "X-Enigmail-Draft-Status");
     content = SLStatic.replaceHeader(content, "Openpgp");
@@ -741,6 +735,7 @@ in both node.js and browser environments without a lot of awkward redundency.
 if (typeof browser === "undefined") {
   var browserMocking = true;
   var mockStorage = {};
+  var moment = require('./moment.min.js');
 
   var browser = {
     storage: {


### PR DESCRIPTION
This should fix the bug described in #10 where the `x-send-later-at` header was being formatted such that it could not subsequently be parsed as a Date.

I had already been using [moment.js](https://momentjs.com/) for some date localization, so this patch just makes that library the default date formatter. Now, strings that are to be presented to the user are formatted separately from strings which are to be parsed again in the future. Parseable strings are always formatted according to ISO-8601 standard.