### PR TITLE
Fix undefined reference error

### DIFF
--- a/ui/options.js
+++ b/ui/options.js
@@ -127,7 +127,7 @@ const SLOptions = {
           case "radio":
             preferences[element.id] = element.checked;
             SLOptions.showCheckMark(element, "green");
-            if (element.checked && SLOptions.checkboxGroups[element.id] !== null)
+            if (element.checked && SLOptions.checkboxGroups[element.id])
               for (const id2 of SLOptions.checkboxGroups[element.id]) {
                 const element2 = document.getElementById(id2);
                 if (element2.checked) {


### PR DESCRIPTION
Some radio box preferences are exclusive, and are grouped together. For those ones we need to iterate over the other preferences in the group and make sure that only one of them can be enabled at a time. If a preference is not in one of those groups, we do not need to do that. This PR fixes a bug where Send Later was trying to iterate on an undefined group. The error was harmless, but showed up in debug logs none the less.