### PR TITLE
Use draft headers as source of truth for recurring message schedule

### DIFF
--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -110,6 +110,29 @@
         ]
       },
       {
+        "name": "saveMessage",
+        "type": "function",
+        "async": true,
+        "description": "Replace a message with new raw content",
+        "parameters": [
+          {
+            "name": "accountId",
+            "type": "string",
+            "description": "New message contents"
+          },
+          {
+            "name": "path",
+            "type": "string",
+            "description": "New message contents"
+          },
+          {
+            "name": "content",
+            "type": "string",
+            "description": "New message contents"
+          }
+        ]
+      },
+      {
         "name":"setHeader",
         "type":"function",
         "async":true,


### PR DESCRIPTION
Previously, Send Later was handling recurrence by storing information about each message's most recent send time in local storage. This works fine on a single machine, but will fail if the same IMAP account is accessed from two separate Thunderbird clients, even asynchronously. Client B will be unaware of the last time Client A sent a particular message.

This patch fixes that, by treating the message headers as a single source of truth for the next scheduled occurrence of each message. When Thunderbird sends a message, it will duplicate the contents of that message, with a new `Message-ID` header, and an updated `X-Send-Later-At` header. It will then delete the original message iff the duplication operation succeeds.

Note: Send Later installed on two clients which are simultaneously connected to the same IMAP server is still unsupported. The two clients currently have no way of knowing about each others existence. This only matters if they happen to both check for scheduled messages simultaneously.