### PR TITLE
Create an "Advanced configuration" editor for local storage, and re-implement 'senddrafts' preference

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -395,6 +395,10 @@
     "message": "Donate",
     "description": ""
   },
+  "advancededitor.title": {
+    "message": "Advanced configuration editor",
+    "description": ""
+  },
   "editorlink.value": {
     "message": "Dynamic function editor",
     "description": ""

--- a/background.js
+++ b/background.js
@@ -293,11 +293,14 @@ const SendLater = {
     mainLoop: function() {
       SLStatic.debug("Entering main loop.");
 
-      SendLater.forAllDrafts(
-        async msg => SendLater.possiblySendMessage(msg.id).catch(SLStatic.error)
-      ).catch(SLStatic.error);
-
       browser.storage.local.get({ "preferences": {} }).then(storage => {
+
+        if (storage.preferences.sendDrafts) {
+          SendLater.forAllDrafts(
+            async msg => SendLater.possiblySendMessage(msg.id).catch(SLStatic.error)
+          ).catch(SLStatic.error);
+        }
+
         if (storage.preferences.markDraftsRead) {
           SendLater.markDraftsRead();
         }

--- a/ui/options.css
+++ b/ui/options.css
@@ -48,6 +48,12 @@ label:hover {
   font-weight: bold;
 }
 
+.subtitle {
+  /* font-size: 1.0em; */
+  margin-bottom: 0.5em;
+  font-weight: bold;
+}
+
 .pre {
   font-family: monospace;
   margin:0px;

--- a/ui/options.html
+++ b/ui/options.html
@@ -244,7 +244,7 @@
             <input id="funcEditReset" type="button" style="margin-right:0.5em;"
               value="Discard changes" class="localized __MSG_reset.label__">
             <input id="funcEditDelete" type="button" style="margin-right:0.5em;"
-              value="Discard changes" class="localized __MSG_delete.label__">
+              value="Delete" class="localized __MSG_delete.label__">
           </div>
         </div>
       </div>
@@ -252,6 +252,25 @@
 
     <section>
       <div class="title option-label localized __MSG_advancedOptionsTitle__">Advanced</div>
+
+      <div id="advancedEditorTitle" class="subtitle option-label" style="cursor:pointer;">
+        <span id="advancedEditorVisibleIndicator"
+          style="margin-right: 0.25em;">+</span>
+        <span class="localized __MSG_advancededitor.title__">
+          Advanced configuration editor</span>
+      </div>
+
+      <div id="advancedConfigEditor" style="display:none;">
+        <textarea id="advancedConfigText" type="textbox"
+            class="pre"
+            style="width:98%;height:60em;margin: 0.25em 0px 0.25em 1em;"></textarea>
+        <div style="padding-left: 4em;">
+          <input id="advancedEditSave" type="button" style="margin-right:0.5em;"
+            value="Save" class="localized __MSG_save.label__">
+          <input id="advancedEditReset" type="button" style="margin-right:0.5em;"
+            value="Discard changes" class="localized __MSG_reset.label__">
+        </div>
+      </div>
 
       <label for="logDumpLevel" style="display:none;">
         <span class="option-label localized __MSG_logDumpLevelLabel__">File log level</span>:

--- a/ui/options.js
+++ b/ui/options.js
@@ -313,6 +313,41 @@ const SLOptions = {
       });
     });
 
+    const resetAdvConfigEditor = (async () => {
+      const prefsNode = document.getElementById("advancedConfigText");
+      prefsNode.disabled = true;
+      prefsNode.textContent = "";
+      const { preferences } = await browser.storage.local.get({"preferences":{}});
+      prefsNode.textContent = JSON.stringify(preferences, null, 2);
+      prefsNode.disabled = false;
+    });
+
+    document.getElementById("advancedEditorTitle").addEventListener("mousedown",
+      (() => {
+        const advEditorDiv = document.getElementById("advancedConfigEditor");
+        const visIndicator = document.getElementById("advancedEditorVisibleIndicator");
+        if (advEditorDiv.style.display === "none") {
+          resetAdvConfigEditor();
+          advEditorDiv.style.display = "block";
+          visIndicator.textContent = "-";
+        } else {
+          advEditorDiv.style.display = "none";
+          visIndicator.textContent = "+";
+        }
+      }));
+
+    document.getElementById("advancedEditReset").addEventListener("click",
+      resetAdvConfigEditor);
+
+    document.getElementById("advancedEditSave").addEventListener("click", evt => {
+      const prefContent = document.getElementById("advancedConfigText").value;
+      const prefs = JSON.parse(prefContent);
+      browser.storage.local.set({ preferences: prefs }).then(() => {
+        browser.runtime.sendMessage({ action: "reloadPrefCache" });
+        SLOptions.applyPrefsToUI();
+      });
+    });
+
     // Verify with user before deleting a scheduling function
     const doubleCheckDeleteListener = SLOptions.doubleCheckButtonClick(evt => {
       const funcNameSelect = document.getElementById("functionNames");
@@ -393,8 +428,9 @@ const SLOptions = {
           }, {});
           browser.storage.local.set({ preferences: prefs }).then(() => {
             browser.runtime.sendMessage({ action: "reloadPrefCache" });
+            SLOptions.applyPrefsToUI();
           });
-      }).then(() => SLOptions.applyPrefsToUI());
+      });
     });
     const clearPrefsBtn = document.getElementById("clearPrefs");
     clearPrefsBtn.addEventListener("click", clearPrefsListener);


### PR DESCRIPTION
The new local storage system for preferences is much more opaque to users, and makes it effectively impossible to modify options without an explicit UI component. This PR adds a home-brew configuration editor for directly modifying all of the Send Later preferences (including legacy ones which are not currently used anywhere).

This came up because of a request to re-enable the 'senddrafts' option, which would have been completely trivial if not for the fact that setting that preference had become impossible.