### PR TITLE
External prefs access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ utils/moment.min.js:
 	curl -sL https://momentjs.com/downloads/moment-with-locales.min.js | \
 		sed -e 's/.*sourceMappingURL.*//' > "$@"
 
-send_later.xpi: $(shell find $(shell cat dev/include-manifest) 2>/dev/null)
+send_later.xpi: $(shell find $(shell cat dev/include-manifest) -type f 2>/dev/null)
 	zip -q -r "$@" . -i@dev/include-manifest
 
 release/send_later-${version}-tb.xpi: send_later.xpi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: release
 
+all: send_later.xpi
+clean: ; -rm -f send_later.xpi
+
 version=$(shell grep -o '"version"\s*:\s*"\S*"' manifest.json | sed -e 's/.*"\([0-9].*\)".*/\1/')
 
 # Kludgey temporary workaround until Crowdin integration is fixed.

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ utils/moment.min.js:
 		sed -e 's/.*sourceMappingURL.*//' > "$@"
 
 send_later.xpi: dev/include-manifest $(shell find $(shell cat dev/include-manifest) -type f 2>/dev/null)
-	rm -f "$@"
-	zip -q -r "$@" . -i@dev/include-manifest
+	rm -f "$@" "$@".tmp
+	zip -q -r "$@".tmp . -i@dev/include-manifest
+	mv "$@".tmp "$@"
 
 release/send_later-${version}-tb.xpi: send_later.xpi
 	mkdir -p "`dirname $@`"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ utils/moment.min.js:
 	curl -sL https://momentjs.com/downloads/moment-with-locales.min.js | \
 		sed -e 's/.*sourceMappingURL.*//' > "$@"
 
-send_later.xpi: $(shell find $(shell cat dev/include-manifest) -type f 2>/dev/null)
+send_later.xpi: dev/include-manifest $(shell find $(shell cat dev/include-manifest) -type f 2>/dev/null)
 	rm -f "$@"
 	zip -q -r "$@" . -i@dev/include-manifest
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ utils/moment.min.js:
 		sed -e 's/.*sourceMappingURL.*//' > "$@"
 
 send_later.xpi: $(shell find $(shell cat dev/include-manifest) -type f 2>/dev/null)
+	rm -f "$@"
 	zip -q -r "$@" . -i@dev/include-manifest
 
 release/send_later-${version}-tb.xpi: send_later.xpi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: release
 
-version=$(shell grep -o '"version"\s*:\s*"\S*"' manifest.json | sed -e 's/.*"\([0-9]\S*\)".*/\1/')
+version=$(shell grep -o '"version"\s*:\s*"\S*"' manifest.json | sed -e 's/.*"\([0-9].*\)".*/\1/')
 
 # Kludgey temporary workaround until Crowdin integration is fixed.
 _locales: dev/migrate_locales.py

--- a/ui/options.js
+++ b/ui/options.js
@@ -2,16 +2,6 @@ window.browser = window.browser.extension.getBackgroundPage().browser;
 
 // Functions related to the options UI (accessed via options.html)
 const SLOptions = {
-  // HTML element IDs correspond to preference keys, and indirectly also to
-  // localization strings.
-  inputIds: ["checkTimePref", "sendDoesDelay", "sendDelay", "sendDoesSL",
-            "altBinding", "markDraftsRead", "showColumn", "showHeader",
-            "showStatus", "blockLateMessages", "lateGracePeriod", "sendUnsentMsgs",
-            "enforceTimeRestrictions", "logDumpLevel", "logConsoleLevel",
-            "quickOptions1Label", "quickOptions1funcselect", "quickOptions1Args",
-            "quickOptions2Label", "quickOptions2funcselect", "quickOptions2Args",
-            "quickOptions3Label", "quickOptions3funcselect", "quickOptions3Args"],
-
   builtinFuncs: ["ReadMeFirst", "BusinessHours", "DaysInARow", "Delay"],
 
   checkboxGroups: {},
@@ -25,7 +15,7 @@ const SLOptions = {
     });
     browser.storage.local.get("preferences").then(storage => {
       const prefs = storage.preferences || {};
-      for (const id of SLOptions.inputIds) {
+      for (const id of SLStatic.prefInputIds) {
         (async (e, v) => {
           if (!e) {
             SLStatic.error(id, e, v);
@@ -234,7 +224,7 @@ const SLOptions = {
 
   async attachListeners() {
     // Attach listeners for all input fields
-    for (const id of SLOptions.inputIds) {
+    for (const id of SLStatic.prefInputIds) {
       const el = document.getElementById(id);
       el.addEventListener("change", SLOptions.updatePrefListener);
     }

--- a/utils/static.js
+++ b/utils/static.js
@@ -13,6 +13,18 @@ var SLStatic = {
   // Indicator to initiate a preference migration.
   CURRENT_LEGACY_MIGRATION: 4,
 
+  // HTML element IDs correspond to preference keys, localization strings, and
+  // keys of preference values in local storage.
+  prefInputIds: ["checkTimePref", "sendDoesDelay", "sendDelay", "sendDoesSL",
+                 "altBinding", "markDraftsRead", "showColumn", "showHeader",
+                 "showStatus", "blockLateMessages", "lateGracePeriod",
+                 "sendUnsentMsgs", "enforceTimeRestrictions", "logDumpLevel",
+                 "logConsoleLevel", "quickOptions1Label",
+                 "quickOptions1funcselect", "quickOptions1Args",
+                 "quickOptions2Label", "quickOptions2funcselect",
+                 "quickOptions2Args", "quickOptions3Label",
+                 "quickOptions3funcselect", "quickOptions3Args"],
+
   async logger(msg, level, stream) {
     const levels = ["all","trace","debug","info","warn","error","fatal"];
     let logConsoleLevel;


### PR DESCRIPTION
First stab at allowing prefs access from outside the add-on, i.e., restoring the ability that was present in TB68 for code running elsewhere to update Send Later preferences.

I personally want to use this to change the sendDoesSL setting based on whether it's a time of day when I want to Send Later by default.

There are also a bunch of minor Makefile fixes here.
