### PR TITLE
Add date string parsing to scheduler dialog

### DIFF
--- a/background.js
+++ b/background.js
@@ -59,7 +59,7 @@ const SendLater = {
       }
     },
 
-    async forAllDrafts(callback) {
+    async forAllDrafts(callback, sequential) {
       try {
         let results = [];
         let accounts = await browser.accounts.list();
@@ -69,7 +69,13 @@ const SendLater = {
             let page = await browser.messages.list(drafts);
             do {
               for (let message of page.messages) {
-                results.push(callback(message));
+                if (sequential === true) {
+                  const result = await callback(message);
+                  results.push(result);
+                } else {
+                  const resultPromise = callback(message);
+                  results.push(resultPromise);
+                }
               }
               if (page.id) {
                 page = await browser.messages.continueList(page.id);
@@ -77,7 +83,11 @@ const SendLater = {
             } while (page.id);
           }
         }
-        return Promise.all(results);
+        if (sequential === true) {
+          return results;
+        } else {
+          return Promise.all(results);
+        }
       } catch (ex) {
         SLStatic.error(ex);
       }

--- a/experiments/headerView.js
+++ b/experiments/headerView.js
@@ -296,7 +296,6 @@ var SendLaterHeaderView = {
     const threadCols = document.getElementById("threadCols");
     threadCols.insertBefore(
       MozXULElement.parseXULToFragment(`
-        <splitter class="tree-splitter"/>
         <treecol id="${this.columnId}"
                 persist="ordinal width"
                 flex="1"
@@ -304,6 +303,7 @@ var SendLaterHeaderView = {
                 currentView="unthreaded"
                 label="${label}">
         </treecol>
+        <splitter class="tree-splitter"/>
         `),
       threadCols.firstChild
     );

--- a/ui/popup.css
+++ b/ui/popup.css
@@ -68,3 +68,20 @@ section {
 label {
   white-space: nowrap;
 }
+
+.div-table {
+  display: table;
+  width:auto;
+}
+
+.div-table-row {
+  display: table-row;
+  width: auto;
+  clear: both;
+}
+
+.div-table-cell {
+  display: table-cell;
+  padding:0.1em;
+  padding-right: 1em;
+}

--- a/ui/popup.html
+++ b/ui/popup.html
@@ -7,10 +7,24 @@
 
   <body style="padding:1em;">
     <section style="display:block;" id="sendAtTimeDateDiv">
-      <span style="margin-right:0.5em;"
-            class="localized __MSG_sendAtLabel__">Send at</span>
-      <input id="send-date" type="date"/>
-      <input id="send-time" type="time"/>
+      <div class="div-table">
+        <div class="div-table-row">
+          <div class="div-table-cell localized __MSG_sendAtLabel__">
+            Send at
+          </div>
+          <div class="div-table-cell">
+            <input id="send-date" type="date"/>
+            <input id="send-time" type="time"/>
+          </div>
+        </div>
+        <div class="div-table-row">
+          <div class="div-table-cell"></div>
+          <div class="div-table-cell">
+            <input id="send-datetime" type="text" style="width:100%"
+              class="localized __MSG_sendAtDefaultLabel__"/>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section style="display:block;">


### PR DESCRIPTION
Plus add an option for sequential processing in forAllDrafts, which may become necessary as a temporary fix for #16. At this point it is not used, but the capability is there.