### PR TITLE
Add instance UUID headers to scheduled messages

### DIFF
--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -705,6 +705,13 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           return false;
         },
 
+        async generateUUID() {
+          const uuidGenerator = Cc["@mozilla.org/uuid-generator;1"].getService(
+            Ci.nsIUUIDGenerator
+          );
+          return uuidGenerator.generateUUID().toString();
+        },
+
         async generateMsgId(content) {
           const idkey = ((/\nX-Identity-Key:\s*(\S+)/i).exec('\n'+content))[1];
           return SendLaterFunctions.generateMsgId(idkey);
@@ -817,7 +824,7 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
               ).toLowerCase().split(/\s+/).filter(v=>(v!==""));
           } catch(e) {}
           let wantedHeaders = ["x-send-later-at", "x-send-later-recur",
-            "x-send-later-args", "x-send-later-cancel-on-reply"];
+            "x-send-later-args", "x-send-later-cancel-on-reply", "x-send-later-uuid"];
 
           const allDefined = wantedHeaders.every(hdr => originals.includes(hdr));
           if (!allDefined) {

--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -414,37 +414,91 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           }
         },
 
+        async setLegacyPref(name, dtype, value) {
+          const prefName = `extensions.sendlater3.${name}`;
+
+          switch (dtype) {
+            case "bool": {
+              const prefValue = (value === "true");
+              try {
+                Services.prefs.setBoolPref(prefName, prefValue);
+                return true;
+              } catch (err) {
+                console.error(err);
+                return false;
+              }
+            }
+            case "int": {
+              const prefValue = (Number(value)|0);
+              try {
+                Services.prefs.setIntPref(prefName, prefValue);
+                return true;
+              } catch (err) {
+                console.error(err);
+                return false;
+              }
+            }
+            case "char": {
+              const prefValue = value;
+              try {
+                Services.prefs.setCharPref(prefName, prefValue);
+                return true;
+              } catch (err) {
+                console.error(err);
+                return false;
+              }
+            }
+            case "string": {
+              const prefValue = value;
+              try {
+                Services.prefs.setStringPref(prefName, prefValue);
+                return true;
+              } catch (err) {
+                console.error(err);
+                return false;
+              }
+            }
+            default: {
+              throw new Error("Unexpected pref type");
+            }
+          }
+        },
+
         async getLegacyPref(name, dtype, defVal) {
           // Prefix for legacy preferences.
           const prefName = `extensions.sendlater3.${name}`;
 
           switch (dtype) {
             case "bool": {
+              const prefDefault = (defVal === "true");
               try {
-                return Services.prefs.getBoolPref(prefName);
+                return Services.prefs.getBoolPref(prefName, prefDefault);
               } catch {
-                return (defVal === "true");
+                return prefDefault;
               }
             }
             case "int": {
+              const prefDefault = (Number(defVal)|0);
               try {
-                return Services.prefs.getIntPref(prefName);
+                return Services.prefs.getIntPref(prefName, prefDefault);
               } catch {
-                return (Number(defVal)|0);
+                return prefDefault;
               }
             }
             case "char": {
+              const prefDefault = defVal;
               try {
-                return Services.prefs.getCharPref(prefName);
-              } catch {
-                return defVal;
+                return Services.prefs.getCharPref(prefName, prefDefault);
+              } catch (err) {
+                return prefDefault;
               }
             }
             case "string": {
+              const prefDefault = defVal;
               try {
-                return Services.prefs.getStringPref(prefName);
-              } catch {
-                return defVal;
+                return Services.prefs.getStringPref(prefName, prefDefault);
+              } catch (err) {
+                return prefDefault;
               }
             }
             default: {

--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -216,6 +216,29 @@
         ]
       },
       {
+        "name": "setLegacyPref",
+        "type": "function",
+        "description": "Sets a preference.",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name."
+          },
+          {
+            "name": "dtype",
+            "type": "string",
+            "description": "Data type of the preference."
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "description": "Preference value as a string."
+          }
+        ]
+      },
+      {
         "name": "getLegacyPref",
         "type": "function",
         "description": "Gets a preference.",
@@ -232,7 +255,7 @@
             "description": "Data type of the preference"
           },
           {
-            "name": "def",
+            "name": "defVal",
             "type": "string",
             "description": "Fallback value if nothing is returned."
           }

--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -62,6 +62,13 @@
         ]
       },
       {
+        "name": "generateUUID",
+        "type": "function",
+        "async": true,
+        "description": "",
+        "parameters": []
+      },
+      {
         "name": "generateMsgId",
         "type": "function",
         "async": true,
@@ -211,7 +218,7 @@
           {
             "name":"msgId",
             "type":"string",
-            "description":"uuid to find"
+            "description":"message-id to find"
           }
         ]
       },

--- a/utils/defaultPrefs.json
+++ b/utils/defaultPrefs.json
@@ -41,5 +41,6 @@
   "editorFirstUse": ["bool", true, "editor.first_use"],
   "promptDefaults": ["string", "", "prompt.defaults"],
   "markDraftsRead": ["bool", true, "mark_drafts_read"],
-  "composeWindowHotkeys": ["bool", true, "compose_window_hot_keys"]
+  "composeWindowHotkeys": ["bool", true, "compose_window_hot_keys"],
+  "instanceUUID": ["string", "", "instance.uuid"]
 }

--- a/utils/static.js
+++ b/utils/static.js
@@ -11,7 +11,7 @@ var SLStatic = {
   previousLoop: new Date(),
 
   // Indicator to initiate a preference migration.
-  CURRENT_LEGACY_MIGRATION: 3,
+  CURRENT_LEGACY_MIGRATION: 4,
 
   async logger(msg, level, stream) {
     const levels = ["all","trace","debug","info","warn","error","fatal"];


### PR DESCRIPTION
Beginning to address #78 
* Import the instance.uuid preference (or generating a new one),
* Add `x-send-later-uuid` header to any newly scheduled messages.
* Update `mailnews.customDBHeaders` to include `x-send-later-uuid` if not already present.