### PR TITLE
Add function to claim any scheduled messages without UUID headers

### DIFF
--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -669,9 +669,11 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
 
           if (verifyId === newMessageId) {
             cw.GenericSendMessage(Ci.nsIMsgCompDeliverMode.SaveAsDraft);
+            return newMessageId;
           } else {
             console.error(`Message ID not set correctly, ${verifyId} != ${newMessageId}`);
           }
+          return null;
         },
 
         async sendNow() {

--- a/utils/static.js
+++ b/utils/static.js
@@ -260,9 +260,11 @@ var SLStatic = {
   },
 
   getHeader: function(content, header) {
+    // Get header's value (e.g. "subject: foo bar    baz" returns "foo bar    baz")
     const regex = new RegExp(`^${header}:([^\r\n]*)\r\n(\\s[^\r\n]*\r\n)*`,'im');
     if (regex.test(content)) {
-      return content.match(regex)[0].trim();
+      const hdrLine = content.match(regex)[0];
+      return hdrLine.replace(/.*:/m,"").trim();
     } else {
       return undefined;
     }


### PR DESCRIPTION
This function takes lots of precautions to not mess anything up during the process of "claiming" messages. Most notably, it seems like #16 might come into play when modifying lots of messages "asynchronously" -- so, this function will do as much as possible in a pseudo-sequential order.

As mentioned in #78 , this should only ever happen once, and only for users who have been following the 8.x beta releases up to now.