### PR TITLE
Ignore messages with different instanceUUID

### DIFF
--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -658,12 +658,11 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           return true;
         },
 
-        async saveAsDraft(idkey) {
+        async saveAsDraft(newMessageId) {
           // Saves the current compose window message as a draft.
           // (Window remains open)
           const cw = Services.wm.getMostRecentWindow("msgcompose");
 
-          const newMessageId = SendLaterFunctions.generateMsgId(idkey);
           cw.gMsgCompose.compFields.setHeader("message-id",newMessageId);
           const verifyId = cw.gMsgCompose.compFields.getHeader("message-id");
 
@@ -714,8 +713,8 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           return uuidGenerator.generateUUID().toString();
         },
 
-        async generateMsgId(content) {
-          const idkey = ((/\nX-Identity-Key:\s*(\S+)/i).exec('\n'+content))[1];
+        async generateMsgId(idkey) {
+          // const idkey = ((/\nX-Identity-Key:\s*(\S+)/i).exec('\n'+content))[1];
           return SendLaterFunctions.generateMsgId(idkey);
         },
 

--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -87,7 +87,7 @@
         "description": "",
         "parameters": [
           {
-            "name": "idkey",
+            "name": "newMessageId",
             "type": "string"
           }
         ]

--- a/test/nextrecurtests.js
+++ b/test/nextrecurtests.js
@@ -153,7 +153,7 @@ exports.init = function() {
   SLTests.AddTest("nextRecurDate function returning minutes",
                    NextRecurFunctionTest,
                    ["10/3/2012", "function Test6", "10/4/2012", null, "Test6",
-                   'return 5', [d1, null]]);
+                   'return 5', [d1, null, null]]);
 
   const d2 = new Date();
   d2.setTime((new Date("10/3/2012")).getTime() + 7 * 60 * 1000);

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -423,7 +423,8 @@ const SLPopup = {
         element.addEventListener("change", async evt => {
           const inputs = SLPopup.objectifyFormValues();
           const schedule = await SLPopup.parseInputs(inputs);
-          SLStatic.stateSetter(schedule.recur.type !== "none")(dom['cancel-on-reply-div']);
+          SLStatic.stateSetter(schedule.recur && schedule.recur.type !== "none")(
+            dom['cancel-on-reply-div']);
           SLPopup.setScheduleButton(schedule);
         });
       }


### PR DESCRIPTION
In addition to ignoring messages without the local instanceUUID header, this commit refactors several parts of the code to avoid asynchronous calls to browser.messages.* api's, and replacing the 'markdraftsread' logic with a more targeted approach that only marks the Send Later drafts as read, and leaves others alone. It also fixes what appeared to be a bug in rescheduling messages with recurrence function arguments.