### PR TITLE
Fix Drafts folder column sorting

### DIFF
--- a/experiments/headerView.js
+++ b/experiments/headerView.js
@@ -69,9 +69,10 @@ var SendLaterHeaderView = {
       const sendAtStr = hdr.getStringProperty("x-send-later-at");
       if (sendAtStr) {
         const sendAt = new Date(sendAtStr);
-        return sendAt.getTime()|0;
+        // Numbers will be truncated. Be sure this fits in 32 bits
+        return (sendAt.getTime()/1000)|0;
       } else {
-        return Number.MAX_SAFE_INTEGER|0;
+        return (Math.pow(2,31)-1)|0;
       }
     },
     getSortStringForRow(hdr) {


### PR DESCRIPTION
Figured out why the 7.x branch divides the time signature by 1000. Should have been obvious in retrospect, but it does not fit into a 32 bit integer otherwise. The drafts folder column should sort properly now!