### PR TITLE
Improve handling of re-sent messages

### DIFF
--- a/background.js
+++ b/background.js
@@ -189,11 +189,16 @@ const SendLater = {
       }
 
       if (lock[originalMsgId]) {
-        SLStatic.log(`Skipping message ${originalMsgId} -- resend!`);
-        const err = browser.i18n.getMessage("MessageResendError", [msgHdr.folder.path]);
-        browser.SL3U.alert("", err);
-        preferences.checkTimePref = 0;
-        await browser.storage.local.set({ preferences });
+        const msgSubject = SLStatic.getHeader(rawContent, 'subject');
+        SLStatic.error(`Attempted to resend message "${msgSubject}" ${originalMsgId}.`)
+        const err = browser.i18n.getMessage("CorruptFolderError", [msgHdr.folder.path]) +
+          `\n\nSpecifically, it appears that message "${msgSubject}" ${originalMsgId} ` +
+          `has been sent before, but still exists in the Drafts folder. This may or may ` +
+          `not be indicative of a more serious problem. You might simply try deleting ` +
+          `(or re-scheduling) the message in question.` +
+          `\n\nSend Later will skip this message, but continue processing your other ` +
+          `scheduled draft messages when you close this alert.`;
+        await browser.SL3U.alert("", err);
         return;
       }
 


### PR DESCRIPTION
When a message is not successfully deleted from drafts, it can get picked up by Send Later a second time. This is uncommon, but right now the user gets a notification, and Send Later disables itself via preferences (sets check interval to 0).

That is basically done under the assumption that something major is wrong, but it could just be a one-off fluke where deleting the original failed for some unrelated reason. In any case,  it might not be indicative of a major underlying problem. It's apparently confusing to users, and it just makes debugging other issues more difficult.

This commit changes that behavior to warn users, skip the message in question, and move on to the next available message without disabling Send Later.