### PR TITLE
Generate UUIDs within webextension context

### DIFF
--- a/background.js
+++ b/background.js
@@ -483,8 +483,8 @@ const SendLater = {
         if (instance_uuid) {
           SLStatic.info(`Using migrated UUID: ${instance_uuid}`);
         } else {
-          SLStatic.info(`Generating new UUID: ${instance_uuid}`);
-          instance_uuid = await browser.SL3U.generateUUID();
+          instance_uuid = SLStatic.generateUUID();
+          SLStatic.info(`Generated new UUID: ${instance_uuid}`);
         }
         preferences.instanceUUID = instance_uuid;
         browser.SL3U.setLegacyPref("instance.uuid", "string", instance_uuid);

--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -692,13 +692,6 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           return false;
         },
 
-        async generateUUID() {
-          const uuidGenerator = Cc["@mozilla.org/uuid-generator;1"].getService(
-            Ci.nsIUUIDGenerator
-          );
-          return uuidGenerator.generateUUID().toString();
-        },
-
         async generateMsgId(idkey) {
           // const idkey = ((/\nX-Identity-Key:\s*(\S+)/i).exec('\n'+content))[1];
           return SendLaterFunctions.generateMsgId(idkey);

--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -39,13 +39,6 @@
         ]
       },
       {
-        "name": "generateUUID",
-        "type": "function",
-        "async": true,
-        "description": "",
-        "parameters": []
-      },
-      {
         "name": "generateMsgId",
         "type": "function",
         "async": true,

--- a/utils/static.js
+++ b/utils/static.js
@@ -50,6 +50,17 @@ var SLStatic = {
                       ), []);
   },
 
+  generateUUID: function() {
+    // Thanks to stackexchange for this one
+    //    https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid
+    // Note: This will eventually be replaced with a standard uuid javascript module
+    // as part of the ecmascript standard.
+    const uuid = ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+      (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    );
+    return `{${uuid}}`;
+  },
+
   parseableDateTimeFormat: function(date) {
     const DATE_RFC2822 = "ddd, DD MMM YYYY HH:mm:ss ZZ";
     return moment(date || (new Date())).locale("en").format(DATE_RFC2822);


### PR DESCRIPTION
Another "experiment" function migrated to extension context. The instanceuuid really just needs to be any random string that will not be shared between instances. Turns out you can do that without anything from Thunderbird's internals.