### PR TITLE
Several optimizations

### DIFF
--- a/background.js
+++ b/background.js
@@ -756,6 +756,7 @@ const SendLater = {
               ufuncs: {}
             });
           SendLater.prefCache = preferences;
+          SLStatic.logConsoleLevel = preferences.logConsoleLevel.toLowerCase();
           const prefString = JSON.stringify(preferences);
           await browser.SL3U.notifyStorageLocal(prefString, false);
         }

--- a/experiments/headerView.js
+++ b/experiments/headerView.js
@@ -192,6 +192,7 @@ var SendLaterHeaderView = {
         return localStorage;
       })(JSON.parse(data));
       SendLaterHeaderView.storageLocalMap = storageMap;
+      SLStatic.logConsoleLevel = (storageMap.get("logConsoleLevel")||"all").toLowerCase();
       SLStatic.debug("StorageLocalMap:",storageMap);
       SLStatic.debug("Leaving function","SendLaterHeaderView.storageLocalObserver.observe");
     },

--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -396,10 +396,6 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           return Services.prompt.alert(window, (title || ""), (text || ""));
         },
 
-        async isOffline() {
-          return Utils.isOffline;
-        },
-
         async setLegacyPref(name, dtype, value) {
           const prefName = `extensions.sendlater3.${name}`;
 
@@ -894,10 +890,6 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           } else {
             Services.obs.notifyObservers(null, notificationTopic, dataStr);
           }
-        },
-
-        async getVersion() {
-          return extension.version;
         },
 
         async injectScript(filename) {

--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -3,12 +3,6 @@
     "namespace": "SL3U",
     "functions": [
       {
-        "name":"isOffline",
-        "type":"function",
-        "async":true,
-        "parameters":[]
-      },
-      {
         "name":"alert",
         "type":"function",
         "async":true,
@@ -80,13 +74,6 @@
             "type": "string"
           }
         ]
-      },
-      {
-        "name": "getVersion",
-        "type": "function",
-        "async": true,
-        "description": "Get the version number of the currently running extension.",
-        "parameters": []
       },
       {
         "name": "sendNow",

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,8 @@
     "activeTab",
     "messagesMove",
     "messagesRead",
-    "compose"
+    "compose",
+    "notifications"
   ],
 
   "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -38,22 +38,22 @@
 
   "background": {
     "scripts": [
-      "/utils/sugar-custom.js",
-      "/utils/static.js",
-      "/background.js"
+      "utils/sugar-custom.js",
+      "utils/static.js",
+      "background.js"
     ]
   },
 
   "web_accessible_resources": [
-    "/utils/sugar-custom.js",
-    "/utils/static.js",
-    "/utils/defaultPrefs.json",
-    "/experiments/sl3u.js",
-    "/experiments/headerView.js"
+    "utils/sugar-custom.js",
+    "utils/static.js",
+    "utils/defaultPrefs.json",
+    "experiments/sl3u.js",
+    "experiments/headerView.js"
   ],
 
   "options_ui": {
-    "page": "/ui/options.html",
+    "page": "ui/options.html",
     "open_in_tab": false,
     "browser_style": false
   },
@@ -61,15 +61,15 @@
   "compose_action": {
     "browser_style": true,
     "default_area": "maintoolbar",
-    "default_icon": "/ui/icons/icon.png",
-    "default_popup": "/ui/popup.html",
+    "default_icon": "ui/icons/icon.png",
+    "default_popup": "ui/popup.html",
     "default_title": "__MSG_extensionName__"
   },
 
   "message_display_action": {
     "browser_style": true,
-    "default_icon": "/ui/icons/icon.png",
-    "default_popup": "/ui/msgDisplayPopup.html",
+    "default_icon": "ui/icons/icon.png",
+    "default_popup": "ui/msgDisplayPopup.html",
     "default_title": "__MSG_extensionName__"
   },
 

--- a/test/miscellaneoustests.js
+++ b/test/miscellaneoustests.js
@@ -1,4 +1,3 @@
-var moment = require('../utils/moment.min.js');
 
 exports.init = function() {
   // Example
@@ -16,55 +15,55 @@ exports.init = function() {
 
   SLTests.AddTest("Test parseableDateTimeFormat", (input, expected) => {
     const result = SLStatic.parseableDateTimeFormat(new Date(input));
-    return moment(result, "ddd, DD MMM YYYY HH:mm:ss ZZ", true).isSame(expected) ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ "Sun Feb 01 1998 15:03:00 GMT+2", "Sun, 01 Feb 1998 05:03:00 -0800" ]);
 
   SLTests.AddTest("Test humanDateTimeFormat", (input, expected) => {
     const result = SLStatic.humanDateTimeFormat(new Date(input));
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ "Sun Feb 01 1998 15:03:00 GMT+2", "February 1, 1998 5:03 AM" ]);
 
   SLTests.AddTest("Test shortHumanDateTimeFormat", (input, expected) => {
     const result = SLStatic.shortHumanDateTimeFormat(new Date(input));
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ "Sun Feb 01 1998 15:03:00 GMT+2", "2/1/1998, 5:03 AM" ]);
 
   SLTests.AddTest("Test getWkdayName Sunday", (input, expected) => {
     const result = SLStatic.getWkdayName(input[0], input[1]);
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ [0, null], "Sunday" ]);
 
   SLTests.AddTest("Test getWkdayName Tuesday long", (input, expected) => {
     const result = SLStatic.getWkdayName(input[0], input[1]);
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ [2, "long"], "Tuesday" ]);
 
   SLTests.AddTest("Test getWkdayName Wednesday short", (input, expected) => {
     const result = SLStatic.getWkdayName(input[0], input[1]);
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ [3, "short"], "Wed" ]);
 
   SLTests.AddTest("Test formatTime from number", (input, expected) => {
     const result = SLStatic.formatTime(input[0], input[1]);
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ [(new Date(2020,5,3,6,55)).getTime(), true], "0655" ]);
 
   SLTests.AddTest("Test formatTime from date", (input, expected) => {
     const result = SLStatic.formatTime(input[0], input[1]);
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ [(new Date(2020,5,3,6,5)), false], "605" ]);
 
   SLTests.AddTest("Test formatTime from string", (input, expected) => {
     const result = SLStatic.formatTime(input[0], input[1]);
-    return `${result}` === `${expected}` ||
+    return result == expected ||
           `Expected "${expected}", got "${result}"`;
   }, [ ["4:02", true], "0402" ]);
 

--- a/ui/options.js
+++ b/ui/options.js
@@ -52,6 +52,7 @@ const SLOptions = {
 
     const prefPromise =
       browser.storage.local.get({ preferences: {} }).then(({ preferences }) => {
+        SLStatic.logConsoleLevel = (preferences.logConsoleLevel||"all").toLowerCase();
         for (let id of SLStatic.prefInputIds) {
           console.debug(`Setting ${id}: ${preferences[id]}`);
           SLOptions.applyValue(

--- a/ui/options.js
+++ b/ui/options.js
@@ -33,9 +33,9 @@ const SLOptions = {
         if (matchingChildren.length === 1) {
           element.value = matchingChildren[0].value;
         } else if (matchingChildren.length > 1) {
-          console.log("[SendLater]: Multiple options match",value,element);
+          SLStatic.log("[SendLater]: Multiple options match",value,element);
         } else {
-          console.log("[SendLater]: Could not find value in element ",value,element);
+          SLStatic.log("[SendLater]: Could not find value in element ",value,element);
         }
       }
     }
@@ -45,7 +45,7 @@ const SLOptions = {
     const ufuncPromise =
       browser.storage.local.get({ufuncs:{}}).then(({ ufuncs }) => {
         Object.keys(ufuncs).forEach(funcName => {
-          console.debug(`Adding function element ${funcName}`);
+          SLStatic.debug(`Adding function element ${funcName}`);
           SLOptions.addFuncOption(funcName, false);
         })
       });
@@ -54,7 +54,7 @@ const SLOptions = {
       browser.storage.local.get({ preferences: {} }).then(({ preferences }) => {
         SLStatic.logConsoleLevel = (preferences.logConsoleLevel||"all").toLowerCase();
         for (let id of SLStatic.prefInputIds) {
-          console.debug(`Setting ${id}: ${preferences[id]}`);
+          SLStatic.debug(`Setting ${id}: ${preferences[id]}`);
           SLOptions.applyValue(
             id, preferences[id]
           ).catch(SLStatic.error);
@@ -161,21 +161,21 @@ const SLOptions = {
           case "radio":
             preferences[element.id] = element.checked;
             SLOptions.showCheckMark(element, "green");
-            console.debug(`Set option (radio) ${element.id}: ${element.value}`);
+            SLStatic.debug(`Set option (radio) ${element.id}: ${element.value}`);
             if (element.checked && SLOptions.checkboxGroups[element.id])
               for (const id2 of SLOptions.checkboxGroups[element.id]) {
                 const element2 = document.getElementById(id2);
                 if (element2.checked) {
                   element2.checked = false;
                   preferences[id2] = false;
-                  console.debug(`Set option (radio) ${id2}: false`);
+                  SLStatic.debug(`Set option (radio) ${id2}: false`);
                   SLOptions.showCheckMark(element2, "green");
                 }
               }
             break;
           case "text":
           case "number":
-            console.debug(`Set option (number) ${element.id}: ${preferences[element.id]} -> ${element.value}`);
+            SLStatic.debug(`Set option (number) ${element.id}: ${preferences[element.id]} -> ${element.value}`);
             preferences[element.id] = element.value;
             SLOptions.showCheckMark(element, "green");
             break;
@@ -183,7 +183,7 @@ const SLOptions = {
             throw new Error("Unexpected element type: "+element.type);
         }
       } else if (element.tagName === "SELECT") {
-        console.debug(`Set option (select) ${element.id}: ${preferences[element.id]} -> ${element.value}`);
+        SLStatic.debug(`Set option (select) ${element.id}: ${preferences[element.id]} -> ${element.value}`);
         preferences[element.id] = element.value;
         SLOptions.showCheckMark(element, "green");
       } else {

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -14,7 +14,7 @@ const SLPopup = {
       const debugMsg = Object.keys(hdr).reduce((msg,name) => {
         msg.push(`${name}: ${hdr[name]}`); return msg;
       },[]).join("\n    ");
-      console.debug(`DEBUG [SendLater]: Header values:\n    ${debugMsg}`);
+      SLStatic.debug(`DEBUG [SendLater]: Header values:\n    ${debugMsg}`);
     }
   },
 

--- a/utils/static.js
+++ b/utils/static.js
@@ -21,27 +21,37 @@ var SLStatic = {
                  "quickOptions2Args", "quickOptions3Label",
                  "quickOptions3funcselect", "quickOptions3Args"],
 
-  async logger(msg, level, stream) {
-    const levels = ["all","trace","debug","info","warn","error","fatal"];
-    let logConsoleLevel;
-    try {
-      const { preferences } = await browser.storage.local.get({"preferences": {}});
-      logConsoleLevel = preferences.logConsoleLevel.toLowerCase();
-    } catch {
-      logConsoleLevel = "all";
-    }
-    if (levels.indexOf(level) >= levels.indexOf(logConsoleLevel)) {
-      const output = stream || console.log;
-      output(`${level.toUpperCase()} [SendLater]:`, ...msg);
-    }
+  logConsoleLevel: null,
+
+  logger(msg, level, stream) {
+    (async (logConsoleLevel) => {
+      if (logConsoleLevel) {
+        return logConsoleLevel;
+      } else {
+        try {
+          console.log("Checking logConsoleLevel preference");
+          const { preferences } = await browser.storage.local.get({"preferences": {}});
+          return preferences.logConsoleLevel.toLowerCase();
+        } catch {
+          return "all";
+        }
+      }
+    })(this.logConsoleLevel).then((logConsoleLevel) => {
+      this.logConsoleLevel = logConsoleLevel;
+      const levels = ["all","trace","debug","info","warn","error","fatal"];
+      if (levels.indexOf(level) >= levels.indexOf(logConsoleLevel)) {
+        const output = stream || console.log;
+        output(`${level.toUpperCase()} [SendLater]:`, ...msg);
+      }
+    });
   },
 
-  async error(...msg)  { SLStatic.logger(msg, "error", console.error) },
-  async warn(...msg)   { SLStatic.logger(msg, "warn",  console.warn) },
-  async info(...msg)   { SLStatic.logger(msg, "info",  console.info) },
-  async log(...msg)    { SLStatic.logger(msg, "info",  console.log) },
-  async debug(...msg)  { SLStatic.logger(msg, "debug", console.debug) },
-  async trace(...msg)  { SLStatic.logger(msg, "trace", console.trace) },
+  error(...msg)  { SLStatic.logger(msg, "error", console.error) },
+  warn(...msg)   { SLStatic.logger(msg, "warn",  console.warn) },
+  info(...msg)   { SLStatic.logger(msg, "info",  console.info) },
+  log(...msg)    { SLStatic.logger(msg, "info",  console.log) },
+  debug(...msg)  { SLStatic.logger(msg, "debug", console.debug) },
+  trace(...msg)  { SLStatic.logger(msg, "trace", console.trace) },
 
   flatten: function(arr) {
     // Flattens an N-dimensional array.

--- a/utils/static.js
+++ b/utils/static.js
@@ -194,13 +194,15 @@ var SLStatic = {
       throw `Recurrence function "${name}" did not return number, Date, or array`;
     }
 
+    const prevOrNow = prev ? (new Date(prev)).getTime() : Date.now();
+
     switch (recvdType) {
       case "number":
         if (response < 0) {
           return { sendAt: null };
         } else {
           return {
-            sendAt: new Date((new Date(prev)).getTime() + response * 60 * 1000)
+            sendAt: new Date(prevOrNow + response * 60 * 1000)
           };
         }
       case "date":
@@ -214,7 +216,7 @@ var SLStatic = {
           if (response[0] < 0) {
             return { sendAt: null };
           } else {
-            sendAt = new Date((new Date(prev)).getTime() + response[0] * 60 * 1000);
+            sendAt = new Date(prevOrNow + response[0] * 60 * 1000);
           }
         } else if (response[0].getTime) {
           sendAt = response[0];

--- a/utils/static.js
+++ b/utils/static.js
@@ -876,7 +876,7 @@ if (SLStatic.i18n === null) {
             }
 
             if (str === undefined) {
-              console.warn(`Unable to find message ${messageName} in locale ${defaultLocale}`);
+              SLStatic.warn(`Unable to find message ${messageName} in locale ${defaultLocale}`);
               for (let locale of ext.localeData.availableLocales) {
                 if (ext.localeData.messages.has(locale)) {
                   messages = ext.localeData.messages.get(locale);
@@ -919,9 +919,9 @@ if (SLStatic.i18n === null) {
           return "";
         },
       };
-      console.debug("Got i18n locales from extension", SLStatic.i18n);
+      SLStatic.debug("Got i18n locales from extension", SLStatic.i18n);
     } catch (e) {
-      console.debug("Unable to load i18n from extension.",e);
+      SLStatic.debug("Unable to load i18n from extension.",e);
     }
   } else {
     // We're in a node process (unit test).

--- a/utils/static.js
+++ b/utils/static.js
@@ -997,8 +997,7 @@ if (typeof browser === "undefined" && typeof require !== "undefined") {
       sendNow: function(batch){},
       setHeader: function (key,value){},
       getHeader: function(key){return key;},
-      getLegacyPref: function(name, dtype, def){return null;},
-      alert: function(msg) {console.warn(`ALERT ${msg}`);}
+      getLegacyPref: function(name, dtype, def){return null;}
     }
   }
 


### PR DESCRIPTION
I had been querying the storage.local preferences to check what the user's preferred log level was *every single time something was written to the console*, which is a ridiculous thing to do. Part of this PR addresses that by caching the logConsoleLevel in a member variable.

This PR also removes two more experiment functions (getVersion and isOffline) in favor of webextension-friendly alternatives, and moves away from the experimental `alert` function in favor of native notifications. This is only really practical in a couple cases, though. I'm still looking for a way to do blocking alerts, and alerts with interactive buttons.

And lastly it addresses a bug in cases where user functions return a number rather than a date (converts the number into a date with that number of minutes in the future).