### PR TITLE
Overlay should manually check storage.local preferences during onLoad

### DIFF
--- a/background.js
+++ b/background.js
@@ -750,10 +750,10 @@ const SendLater = {
 
       await SendLater.claimDrafts();
 
-      const { preferences } = await browser.storage.local.get({
-          preferences: {},
-          ufuncs: {},
-        });
+      const { preferences } =
+        await browser.storage.local.get({ preferences: {} });
+      SendLater.prefCache = preferences;
+      SLStatic.logConsoleLevel = preferences.logConsoleLevel.toLowerCase();
 
       // This listener should be added *after* all of the storate-related
       // setup is complete. It makes sure that subsequent changes to storage
@@ -761,11 +761,8 @@ const SendLater = {
       browser.storage.onChanged.addListener(async (changes, areaName) => {
         if (areaName === "local") {
           SLStatic.debug("Propagating changes from local storage");
-          const { preferences, ufuncs } =
-            await browser.storage.local.get({
-              preferences: {},
-              ufuncs: {}
-            });
+          const { preferences } =
+            await browser.storage.local.get({ preferences: {} });
           SendLater.prefCache = preferences;
           SLStatic.logConsoleLevel = preferences.logConsoleLevel.toLowerCase();
           const prefString = JSON.stringify(preferences);
@@ -777,9 +774,10 @@ const SendLater = {
       await browser.SL3U.injectScript("utils/static.js");
       await browser.SL3U.injectScript("experiments/headerView.js");
 
-      SendLater.prefCache = preferences;
-      const prefString = JSON.stringify(preferences);
-      await browser.SL3U.notifyStorageLocal(prefString, true);
+      setTimeout(() => {
+        const prefString = JSON.stringify(preferences);
+        browser.SL3U.notifyStorageLocal(prefString, true);
+      }, 1000);
 
       SLStatic.debug("Registering window listeners");
       await browser.SL3U.startObservers();

--- a/experiments/headerView.js
+++ b/experiments/headerView.js
@@ -384,8 +384,22 @@ var SendLaterHeaderView = {
     onOperationCancelled(addon) {},
   },
 
-  onLoad() {
+  async onLoad() {
     SLStatic.debug("Entering function","SendLaterHeaderView.onLoad");
+    try {
+      const ext = window.ExtensionParent.GlobalManager.extensionMap.get("sendlater3@kamens.us");
+      const localStorage = [...ext.views][0].apiCan.findAPIPath("storage.local");
+      const { preferences } = await localStorage.callMethodInParentProcess("get", [{ "preferences": {} }]);
+
+      let storageMap = new Map();
+      Object.entries(preferences).forEach(([key, value]) => {
+        storageMap.set(key, value);
+      });
+      this.storageLocalMap = storageMap;
+      SLStatic.logConsoleLevel =
+        (preferences.logConsoleLevel||"all").toLowerCase();
+    } catch (err) { SLStatic.error("Could not fetch preferences", err); }
+
     Services.obs.addObserver(this.storageLocalObserver, this.obsTopicStorageLocal);
     Services.obs.notifyObservers(null, this.obsNotificationReadyTopic);
 


### PR DESCRIPTION
The drafts column overlay script keeps a cached map of preferences that should stay up to date with storage.local. That cache was initialized during the injectScript step when SendLater is first loaded, and is updated any time storage.local changes. However, when a new window is opened the overlay script is injected, but the preference cache is not initialized.

I could have used the onMessageExternal method for gathering those preferences, but I couldn't immediately figure out how to get a browser.runtime context from outside of an extension or experiment context, so instead I use this even weirder way to get the storage.local api ([as suggested here](https://bugzilla.mozilla.org/show_bug.cgi?id=1653948)). This is a really handy pattern to know about, since now I can access extension apis from anywhere!