### PR TITLE
Improve locale migration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ clean: ; -rm -f send_later.xpi
 version=$(shell grep -o '"version"\s*:\s*"\S*"' manifest.json | sed -e 's/.*"\([0-9].*\)".*/\1/')
 
 # Kludgey temporary workaround until Crowdin integration is fixed.
+# Note that this merges locale updates from the last shared commit before
+# the 8.x branch forked away from 7.x. These are not quite up to date.
 _locales: dev/migrate_locales.py
 	mkdir -p "$@"
 	git restore -s ef21bfd -- chrome/locale

--- a/_locales/bg_BG/messages.json
+++ b/_locales/bg_BG/messages.json
@@ -59,34 +59,6 @@
     "message": "Дъмп ниво на дневника",
     "description": ""
   },
-  "logLevelAll": {
-    "message": "All",
-    "description": ""
-  },
-  "logLevelDebug": {
-    "message": "Debug",
-    "description": ""
-  },
-  "logLevelError": {
-    "message": "Error",
-    "description": ""
-  },
-  "logLevelFatal": {
-    "message": "Fatal",
-    "description": ""
-  },
-  "logLevelInfo": {
-    "message": "Info",
-    "description": ""
-  },
-  "logLevelTrace": {
-    "message": "Trace",
-    "description": ""
-  },
-  "logLevelWarn": {
-    "message": "Warn",
-    "description": ""
-  },
   "markReadPrefLabel": {
     "message": "Маркиране на планираните чернови като прочетени",
     "description": ""
@@ -139,10 +111,6 @@
     "message": "ежеседмично",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Записване на тези стойности по подразбиране",
     "description": ""
@@ -161,14 +129,6 @@
   },
   "sendButtonPrefLabel": {
     "message": "“Изпращане сега” прави същото, като “Изпращане по-късно”",
-    "description": ""
-  },
-  "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
-    "description": ""
-  },
-  "sendDelayPrefLabel2": {
-    "message": "minutes",
     "description": ""
   },
   "sendSundayLabel": {
@@ -225,14 +185,6 @@
   },
   "userGuideLabel": {
     "message": "Ръководство на потребителя",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/ca_ES/messages.json
+++ b/_locales/ca_ES/messages.json
@@ -139,10 +139,6 @@
     "message": "setmanal",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Guardar aquests valors com a valors per omissió",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Guia d'usuari",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/cs_CZ/messages.json
+++ b/_locales/cs_CZ/messages.json
@@ -139,10 +139,6 @@
     "message": "týdně",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Uložit tyto hodnoty jako výchozí",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Uživatelská příručka",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -8,19 +8,19 @@
     "description": "A short description of the add-on."
   },
   "advancedOptionsTitle": {
-    "message": "Geavanceerd",
+    "message": "Advanced",
     "description": ""
   },
   "altBindingPrefLabel": {
-    "message": "Alt-Shift-Enter binden in plaats van Ctrl-Shift-Enter",
+    "message": "Bind Alt-Shift-Enter instead of Ctrl-Shift-Enter",
     "description": ""
   },
   "blockLateMessagesPrefLabel1": {
-    "message": "Berichten niet meer dan",
+    "message": "Don't deliver messages more than",
     "description": ""
   },
   "blockLateMessagesPrefLabel2": {
-    "message": "minuten te laat afleveren",
+    "message": "minutes late",
     "description": ""
   },
   "cancelLabel": {
@@ -28,11 +28,11 @@
     "description": ""
   },
   "checkTimePrefLabel1": {
-    "message": "Elke",
+    "message": "Check every",
     "description": ""
   },
   "checkTimePrefLabel2": {
-    "message": "minuten controleren",
+    "message": "minutes",
     "description": ""
   },
   "clearDefaultsLabel": {
@@ -40,23 +40,23 @@
     "description": ""
   },
   "contactAuthorLabel": {
-    "message": "Contact opnemen met de schrijver",
+    "message": "Contact Maintainer",
     "description": ""
   },
   "enforceRestrictionsPrefLabel": {
-    "message": "Tijds- en dagrestricties bij aflevertijd afdwingen",
+    "message": "Enforce time and day restrictions at delivery time",
     "description": ""
   },
   "generalOptionsTitle": {
-    "message": "Algemeen",
+    "message": "General Options",
     "description": ""
   },
   "logConsoleLevelLabel": {
-    "message": "Consolelogniveau",
+    "message": "Console log level",
     "description": ""
   },
   "logDumpLevelLabel": {
-    "message": "Dumplogniveau",
+    "message": "File log level",
     "description": ""
   },
   "logLevelAll": {
@@ -88,23 +88,23 @@
     "description": ""
   },
   "markReadPrefLabel": {
-    "message": "Markeer geplande concepten als gelezen",
+    "message": "Mark scheduled drafts as read",
     "description": ""
   },
   "quickOptionsLabel1Label": {
-    "message": "Sneltoets 1",
+    "message": "Shortcut 1 label",
     "description": ""
   },
   "quickOptionsLabel2Label": {
-    "message": "Sneltoets 2",
+    "message": "Shortcut 2 label",
     "description": ""
   },
   "quickOptionsLabel3Label": {
-    "message": "Sneltoets 3",
+    "message": "Shortcut 3 label",
     "description": ""
   },
   "quickOptionsValueLabel": {
-    "message": "Minuten",
+    "message": "quickOptionsValueLabel",
     "description": ""
   },
   "recurAnnuallyLabel": {
@@ -160,7 +160,7 @@
     "description": ""
   },
   "sendButtonPrefLabel": {
-    "message": "‘Verzenden’ werkt als ‘Later verzenden’",
+    "message": "\"Send\" does \"Send later\"",
     "description": ""
   },
   "sendDelayPrefLabel1": {
@@ -208,23 +208,23 @@
     "description": ""
   },
   "sendUnsentMessagesPrefLabel": {
-    "message": "Niet-verzonden berichten in Postvak UIT afleveren",
+    "message": "Trigger unsent message delivery from outbox",
     "description": ""
   },
   "showColumnPrefLabel": {
-    "message": "Kolom Send Later tonen",
+    "message": "Show Send Later column",
     "description": ""
   },
   "showHeaderPrefLabel": {
-    "message": "Header Send Later tonen",
+    "message": "Show Send Later header",
     "description": ""
   },
   "showStatusPrefLabel": {
-    "message": "Send Later in statusbalk tonen",
+    "message": "Show Send Later in status bar",
     "description": ""
   },
   "userGuideLabel": {
-    "message": "Handleiding",
+    "message": "Website",
     "description": ""
   },
   "errorDateInPast": {
@@ -235,76 +235,192 @@
     "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
-  "prefwindow.title": {
-    "message": "Send Later-voorkeuren",
+  "sendlater.ask.title.label": {
+    "message": "sendlater.ask.title.label Send Later erstattes ved kørsel med det almindelige navn på tilføjelsen i denne oversættelse (hentning fra MessageTag i background. properties)",
     "description": ""
   },
-  "pane1.title": {
-    "message": "Send Later-voorkeuren",
+  "sendlater.ask.message1": {
+    "message": "Der er brugt utallige timer til udvikling, vedligeholdelse og support af denne tilføjelse.",
     "description": ""
   },
-  "checktimepref.tooltip": {
-    "message": "Interval, in minuten, tussen controles op concepten waarvoor de aflevertijd is bereikt. Vergroot deze waarde als uw concepten niet altijd op tijd worden verzonden of als het aantal af te handelen berichten in uw statusbalk niet altijd overeenkomt met het werkelijke aantal.",
+  "sendlater.ask.message2": {
+    "message": "Overvej om ikke du skulle yde en lille donation for at støtte for den fortsatte udvikling!",
     "description": ""
   },
-  "quickoptionname.label": {
-    "message": "Knoptekst",
+  "sendlater.ask.message3": {
+    "message": "Mange tak!",
     "description": ""
   },
-  "showsendlatercolumn.tooltip": {
-    "message": "Of de kolom ‘Send Later’ bij het bekijken van conceptmappen moet worden getoond",
+  "sendlater.ask.donate.accesskey": {
+    "message": "G",
     "description": ""
   },
-  "showsendlaterheader.tooltip": {
-    "message": "Of de header ‘X-Send-Later-At’ moet worden getoond als een bericht wordt bekeken, m.a.w. de tijd waarop een concept gepland staat om te worden verzonden.",
+  "sendlater.ask.donate.label": {
+    "message": "Giv en donation",
     "description": ""
   },
-  "showsendlaterprogress.caption": {
-    "message": "Achtergrondvoortgang in statusbalk tonen",
+  "sendlater.ask.remind.accesskey": {
+    "message": "M",
     "description": ""
   },
-  "showsendlaterunsentmessages.tooltip": {
-    "message": "Als u deze optie uitvinkt, zal Send Later berichten niet volledig verzenden, maar deze op het moment van verzenden alleen in uw Postvak UIT plaatsen. Vink deze optie uit als u bijvoorbeeld een andere extensie gebruikt, zoals BlunderDelay, die periodiek berichten uit uw Postvak UIT verzendt. Denk eraan dat als deze optie is aangevinkt, Send Later bij het afleveren van een bericht ALLE berichten in uw Postvak UIT aflevert.",
+  "sendlater.ask.remind.label": {
+    "message": "Mind mig om det senere",
     "description": ""
   },
-  "sendlatersendbutton.tooltip": {
-    "message": "Met deze optie ingeschakeld, werkt de opdracht ‘Verzenden’ (via zowel de knop als het intoetsen van Ctrl-Enter) hetzelfde als ‘Later verzenden’.",
+  "sendlater.ask.already.accesskey": {
+    "message": "a",
     "description": ""
   },
-  "contactauthor.tooltip": {
-    "message": "Een e-mailbericht naar de schrijver van Send Later verzenden (in het Engels)",
+  "sendlater.ask.already.label": {
+    "message": "Jeg har allerede doneret",
     "description": ""
   },
-  "helplink.tooltip": {
-    "message": "De documentatie voor Send Later bekijken",
+  "sendlater.ask.stop.accesskey": {
+    "message": "S",
     "description": ""
   },
-  "releasenotes.value": {
-    "message": "Uitgaveopmerkingen",
+  "sendlater.ask.stop.label": {
+    "message": "Spørg ikke igen",
     "description": ""
   },
-  "donatelink.value": {
-    "message": "Doneren",
+  "windowtitle": {
+    "message": "Send Later Redigér Dynamiske Funktioner",
     "description": ""
   },
-  "editorlink.value": {
-    "message": "Editor voor dynamische functies",
+  "selectfunction": {
+    "message": "Vælg funktion",
     "description": ""
   },
-  "enforcerestrictions.tooltip": {
-    "message": "Als een bericht dat dient te worden afgeleverd buiten de tijds- of dagrestricties komt, bijvoorbeeld omdat Thunderbird ten tijde van de geplande aflevertijd niet actief was, vertraag dan de aflevering totdat aan de tijds- en dagrestricties wordt voldaan.",
+  "selectfunctiontip": {
+    "message": "Vælg en funktion, der skal redigeres eller slettes, eller vælg “(opret ny funktion)” for at oprette en ny funktion.",
     "description": ""
   },
-  "blocklatemessages.tooltip": {
-    "message": "Geplande berichten die voorbij hun geplande tijd zijn vertraagd, bijvoorbeeld omdat Thunderbird niet actief was, niet afleveren",
+  "createnewfunction": {
+    "message": "(opret ny funktion)",
     "description": ""
   },
-  "editorbutton": {
-    "message": "Editor voor dynamische functies openen…",
+  "delete.label": {
+    "message": "Slet",
     "description": ""
   },
-  "editortip": {
-    "message": "Een venster openen voor het maken en bewerken van JavaScript-functies die complexe planningslogica implementeren.",
+  "delete.accesskey": {
+    "message": "S",
+    "description": ""
+  },
+  "functionnametip": {
+    "message": "Indtast eller rediger et alfanumerisk funktionsnavn. Hvis du ændrer navnet på en eksisterende funktion, bliver du spurgt, når du gemmer, om du vil omdøbe funktionen eller oprette en ny funktion med det ændrede navn.",
+    "description": ""
+  },
+  "functionnameplaceholder": {
+    "message": "funktions navn",
+    "description": ""
+  },
+  "codetip": {
+    "message": "Indsæt kildekoden til din funktion her. Se prøvefunktionen “ReadMeFirst” for detaljer om, hvad din kode burde gøre.",
+    "description": ""
+  },
+  "codeplaceholder": {
+    "message": "funktions kildekode",
+    "description": ""
+  },
+  "helptextheader": {
+    "message": "Funktionens hjælpetekst",
+    "description": ""
+  },
+  "helptexttip": {
+    "message": "Enhver tekst, du lægger her, vises, når musen “svæver” over funktionsnavnet i pop-up-menuen. Brug den til at forklare, hvad funktionen gør, og hvilke argumenter der kan bruges.",
+    "description": ""
+  },
+  "helptextplaceholder": {
+    "message": "hjælpetekst",
+    "description": ""
+  },
+  "run.label": {
+    "message": "Udfør funktion",
+    "description": ""
+  },
+  "run.accesskey": {
+    "message": "U",
+    "description": ""
+  },
+  "inputtime": {
+    "message": "Indtast tidspunkt",
+    "description": ""
+  },
+  "inputtimetip": {
+    "message": "Du kan indtaste datoer og tidspunkter her i ethvert format, som Send Later -dialogen forstår.",
+    "description": ""
+  },
+  "inputtimeplaceholder": {
+    "message": "evt. dato og klokkeslæt, som overføres til funktionen for afprøvning",
+    "description": ""
+  },
+  "inputargs": {
+    "message": "Indtast værdi",
+    "description": ""
+  },
+  "inputargstip": {
+    "message": "Argumenter skal specificeres i JavaScript-format, tekststrenge f.eks., skal være i anførselstegn.",
+    "description": ""
+  },
+  "inputargsplaceholder": {
+    "message": "eventuelle komma-adskilte værdier som sendes til test",
+    "description": ""
+  },
+  "output": {
+    "message": "Resultat",
+    "description": ""
+  },
+  "import.label": {
+    "message": "Importér…",
+    "description": ""
+  },
+  "import.accesskey": {
+    "message": "m",
+    "description": ""
+  },
+  "importtip": {
+    "message": "Importer en dynamisk funktion, der tidligere er eksporteret fra editoren.",
+    "description": ""
+  },
+  "export.label": {
+    "message": "Eksporter…",
+    "description": ""
+  },
+  "export.accesskey": {
+    "message": "E",
+    "description": ""
+  },
+  "exporttip": {
+    "message": "Eksporter den aktuelt viste funktion til en fil til sikkerhedskopiering eller deling.",
+    "description": ""
+  },
+  "reset.label": {
+    "message": "Kasser ændringer",
+    "description": ""
+  },
+  "reset.accesskey": {
+    "message": "a",
+    "description": ""
+  },
+  "save.label": {
+    "message": "Gem",
+    "description": ""
+  },
+  "save.accesskey": {
+    "message": "G",
+    "description": ""
+  },
+  "close.label": {
+    "message": "Luk",
+    "description": ""
+  },
+  "close.accesskey": {
+    "message": "L",
+    "description": ""
+  },
+  "close.cmdkey": {
+    "message": "w",
     "description": ""
   }
 }

--- a/_locales/da_DK/messages.json
+++ b/_locales/da_DK/messages.json
@@ -1,310 +1,190 @@
 {
-  "extensionName": {
-    "message": "Send Later",
-    "description": "The name of the add-on, displayed in various places."
-  },
-  "extensionDescription": {
-    "message": "True \"Send Later\" functionality to schedule the time for sending an email.",
-    "description": "A short description of the add-on."
-  },
-  "advancedOptionsTitle": {
-    "message": "Geavanceerd",
-    "description": ""
-  },
-  "altBindingPrefLabel": {
-    "message": "Alt-Shift-Enter binden in plaats van Ctrl-Shift-Enter",
-    "description": ""
-  },
-  "blockLateMessagesPrefLabel1": {
-    "message": "Berichten niet meer dan",
-    "description": ""
-  },
-  "blockLateMessagesPrefLabel2": {
-    "message": "minuten te laat afleveren",
-    "description": ""
-  },
-  "cancelLabel": {
-    "message": "Cancel",
-    "description": ""
-  },
-  "checkTimePrefLabel1": {
-    "message": "Elke",
-    "description": ""
-  },
-  "checkTimePrefLabel2": {
-    "message": "minuten controleren",
-    "description": ""
-  },
-  "clearDefaultsLabel": {
-    "message": "Clear Defaults",
-    "description": ""
-  },
-  "contactAuthorLabel": {
-    "message": "Contact opnemen met de schrijver",
-    "description": ""
-  },
-  "enforceRestrictionsPrefLabel": {
-    "message": "Tijds- en dagrestricties bij aflevertijd afdwingen",
-    "description": ""
-  },
-  "generalOptionsTitle": {
-    "message": "Algemeen",
-    "description": ""
-  },
-  "logConsoleLevelLabel": {
-    "message": "Consolelogniveau",
-    "description": ""
-  },
-  "logDumpLevelLabel": {
-    "message": "Dumplogniveau",
-    "description": ""
-  },
-  "logLevelAll": {
-    "message": "All",
+  "sendlater.ask.title.label": {
+    "message": "sendlater.ask.title.label Send Later erstattes ved kørsel med det almindelige navn på tilføjelsen i denne oversættelse (hentning fra MessageTag i background. properties)",
     "description": ""
   },
-  "logLevelDebug": {
-    "message": "Debug",
+  "sendlater.ask.message1": {
+    "message": "Der er brugt utallige timer til udvikling, vedligeholdelse og support af denne tilføjelse.",
     "description": ""
   },
-  "logLevelError": {
-    "message": "Error",
+  "sendlater.ask.message2": {
+    "message": "Overvej om ikke du skulle yde en lille donation for at støtte for den fortsatte udvikling!",
     "description": ""
   },
-  "logLevelFatal": {
-    "message": "Fatal",
+  "sendlater.ask.message3": {
+    "message": "Mange tak!",
     "description": ""
   },
-  "logLevelInfo": {
-    "message": "Info",
+  "sendlater.ask.donate.accesskey": {
+    "message": "G",
     "description": ""
   },
-  "logLevelTrace": {
-    "message": "Trace",
+  "sendlater.ask.donate.label": {
+    "message": "Giv en donation",
     "description": ""
   },
-  "logLevelWarn": {
-    "message": "Warn",
+  "sendlater.ask.remind.accesskey": {
+    "message": "M",
     "description": ""
   },
-  "markReadPrefLabel": {
-    "message": "Markeer geplande concepten als gelezen",
+  "sendlater.ask.remind.label": {
+    "message": "Mind mig om det senere",
     "description": ""
-  },
-  "quickOptionsLabel1Label": {
-    "message": "Sneltoets 1",
-    "description": ""
-  },
-  "quickOptionsLabel2Label": {
-    "message": "Sneltoets 2",
-    "description": ""
-  },
-  "quickOptionsLabel3Label": {
-    "message": "Sneltoets 3",
-    "description": ""
-  },
-  "quickOptionsValueLabel": {
-    "message": "Minuten",
-    "description": ""
-  },
-  "recurAnnuallyLabel": {
-    "message": "Annually",
-    "description": ""
-  },
-  "recurDailyLabel": {
-    "message": "Daily",
-    "description": ""
-  },
-  "recurFunctionLabel": {
-    "message": "Function",
-    "description": ""
-  },
-  "recurLabel": {
-    "message": "Recur",
-    "description": ""
-  },
-  "recurMinutelyLabel": {
-    "message": "Minutely",
-    "description": ""
-  },
-  "recurMonthlyLabel": {
-    "message": "Monthly",
-    "description": ""
-  },
-  "recurOnceLabel": {
-    "message": "Once",
-    "description": ""
-  },
-  "recurWeeklyLabel": {
-    "message": "Weekly",
-    "description": ""
-  },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
-  "saveDefaultsLabel": {
-    "message": "Save these values as defaults",
-    "description": ""
-  },
-  "sendAtDefaultLabel": {
-    "message": "Enter a date above",
-    "description": "Displayed in place of send at time before user makes selections"
   },
-  "sendAtLabel": {
-    "message": "Send at",
+  "sendlater.ask.already.accesskey": {
+    "message": "a",
     "description": ""
   },
-  "sendBtwnLabel": {
-    "message": "Between",
+  "sendlater.ask.already.label": {
+    "message": "Jeg har allerede doneret",
     "description": ""
   },
-  "sendButtonPrefLabel": {
-    "message": "‘Verzenden’ werkt als ‘Later verzenden’",
+  "sendlater.ask.stop.accesskey": {
+    "message": "S",
     "description": ""
   },
-  "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+  "sendlater.ask.stop.label": {
+    "message": "Spørg ikke igen",
     "description": ""
   },
-  "sendDelayPrefLabel2": {
-    "message": "minutes",
+  "windowtitle": {
+    "message": "Send Later Redigér Dynamiske Funktioner",
     "description": ""
   },
-  "sendSundayLabel": {
-    "message": "Sunday",
+  "selectfunction": {
+    "message": "Vælg funktion",
     "description": ""
   },
-  "sendMondayLabel": {
-    "message": "Monday",
+  "selectfunctiontip": {
+    "message": "Vælg en funktion, der skal redigeres eller slettes, eller vælg “(opret ny funktion)” for at oprette en ny funktion.",
     "description": ""
   },
-  "sendTuesdayLabel": {
-    "message": "Tuesday",
+  "createnewfunction": {
+    "message": "(opret ny funktion)",
     "description": ""
   },
-  "sendWednesdayLabel": {
-    "message": "Wednesday",
+  "delete.label": {
+    "message": "Slet",
     "description": ""
   },
-  "sendThursdayLabel": {
-    "message": "Thursday",
+  "delete.accesskey": {
+    "message": "S",
     "description": ""
   },
-  "sendFridayLabel": {
-    "message": "Friday",
+  "functionnametip": {
+    "message": "Indtast eller rediger et alfanumerisk funktionsnavn. Hvis du ændrer navnet på en eksisterende funktion, bliver du spurgt, når du gemmer, om du vil omdøbe funktionen eller oprette en ny funktion med det ændrede navn.",
     "description": ""
   },
-  "sendSaturdayLabel": {
-    "message": "Saturday",
+  "functionnameplaceholder": {
+    "message": "funktions navn",
     "description": ""
   },
-  "sendNowLabel": {
-    "message": "Send now",
+  "codetip": {
+    "message": "Indsæt kildekoden til din funktion her. Se prøvefunktionen “ReadMeFirst” for detaljer om, hvad din kode burde gøre.",
     "description": ""
   },
-  "sendOnlyOnLabel": {
-    "message": "Only on",
+  "codeplaceholder": {
+    "message": "funktions kildekode",
     "description": ""
   },
-  "sendUnsentMessagesPrefLabel": {
-    "message": "Niet-verzonden berichten in Postvak UIT afleveren",
+  "helptextheader": {
+    "message": "Funktionens hjælpetekst",
     "description": ""
   },
-  "showColumnPrefLabel": {
-    "message": "Kolom Send Later tonen",
+  "helptexttip": {
+    "message": "Enhver tekst, du lægger her, vises, når musen “svæver” over funktionsnavnet i pop-up-menuen. Brug den til at forklare, hvad funktionen gør, og hvilke argumenter der kan bruges.",
     "description": ""
   },
-  "showHeaderPrefLabel": {
-    "message": "Header Send Later tonen",
+  "helptextplaceholder": {
+    "message": "hjælpetekst",
     "description": ""
   },
-  "showStatusPrefLabel": {
-    "message": "Send Later in statusbalk tonen",
+  "run.label": {
+    "message": "Udfør funktion",
     "description": ""
   },
-  "userGuideLabel": {
-    "message": "Handleiding",
+  "run.accesskey": {
+    "message": "U",
     "description": ""
   },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
+  "inputtime": {
+    "message": "Indtast tidspunkt",
     "description": ""
   },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
+  "inputtimetip": {
+    "message": "Du kan indtaste datoer og tidspunkter her i ethvert format, som Send Later -dialogen forstår.",
     "description": ""
   },
-  "prefwindow.title": {
-    "message": "Send Later-voorkeuren",
+  "inputtimeplaceholder": {
+    "message": "evt. dato og klokkeslæt, som overføres til funktionen for afprøvning",
     "description": ""
   },
-  "pane1.title": {
-    "message": "Send Later-voorkeuren",
+  "inputargs": {
+    "message": "Indtast værdi",
     "description": ""
   },
-  "checktimepref.tooltip": {
-    "message": "Interval, in minuten, tussen controles op concepten waarvoor de aflevertijd is bereikt. Vergroot deze waarde als uw concepten niet altijd op tijd worden verzonden of als het aantal af te handelen berichten in uw statusbalk niet altijd overeenkomt met het werkelijke aantal.",
+  "inputargstip": {
+    "message": "Argumenter skal specificeres i JavaScript-format, tekststrenge f.eks., skal være i anførselstegn.",
     "description": ""
   },
-  "quickoptionname.label": {
-    "message": "Knoptekst",
+  "inputargsplaceholder": {
+    "message": "eventuelle komma-adskilte værdier som sendes til test",
     "description": ""
   },
-  "showsendlatercolumn.tooltip": {
-    "message": "Of de kolom ‘Send Later’ bij het bekijken van conceptmappen moet worden getoond",
+  "output": {
+    "message": "Resultat",
     "description": ""
   },
-  "showsendlaterheader.tooltip": {
-    "message": "Of de header ‘X-Send-Later-At’ moet worden getoond als een bericht wordt bekeken, m.a.w. de tijd waarop een concept gepland staat om te worden verzonden.",
+  "import.label": {
+    "message": "Importér…",
     "description": ""
   },
-  "showsendlaterprogress.caption": {
-    "message": "Achtergrondvoortgang in statusbalk tonen",
+  "import.accesskey": {
+    "message": "m",
     "description": ""
   },
-  "showsendlaterunsentmessages.tooltip": {
-    "message": "Als u deze optie uitvinkt, zal Send Later berichten niet volledig verzenden, maar deze op het moment van verzenden alleen in uw Postvak UIT plaatsen. Vink deze optie uit als u bijvoorbeeld een andere extensie gebruikt, zoals BlunderDelay, die periodiek berichten uit uw Postvak UIT verzendt. Denk eraan dat als deze optie is aangevinkt, Send Later bij het afleveren van een bericht ALLE berichten in uw Postvak UIT aflevert.",
+  "importtip": {
+    "message": "Importer en dynamisk funktion, der tidligere er eksporteret fra editoren.",
     "description": ""
   },
-  "sendlatersendbutton.tooltip": {
-    "message": "Met deze optie ingeschakeld, werkt de opdracht ‘Verzenden’ (via zowel de knop als het intoetsen van Ctrl-Enter) hetzelfde als ‘Later verzenden’.",
+  "export.label": {
+    "message": "Eksporter…",
     "description": ""
   },
-  "contactauthor.tooltip": {
-    "message": "Een e-mailbericht naar de schrijver van Send Later verzenden (in het Engels)",
+  "export.accesskey": {
+    "message": "E",
     "description": ""
   },
-  "helplink.tooltip": {
-    "message": "De documentatie voor Send Later bekijken",
+  "exporttip": {
+    "message": "Eksporter den aktuelt viste funktion til en fil til sikkerhedskopiering eller deling.",
     "description": ""
   },
-  "releasenotes.value": {
-    "message": "Uitgaveopmerkingen",
+  "reset.label": {
+    "message": "Kasser ændringer",
     "description": ""
   },
-  "donatelink.value": {
-    "message": "Doneren",
+  "reset.accesskey": {
+    "message": "a",
     "description": ""
   },
-  "editorlink.value": {
-    "message": "Editor voor dynamische functies",
+  "save.label": {
+    "message": "Gem",
     "description": ""
   },
-  "enforcerestrictions.tooltip": {
-    "message": "Als een bericht dat dient te worden afgeleverd buiten de tijds- of dagrestricties komt, bijvoorbeeld omdat Thunderbird ten tijde van de geplande aflevertijd niet actief was, vertraag dan de aflevering totdat aan de tijds- en dagrestricties wordt voldaan.",
+  "save.accesskey": {
+    "message": "G",
     "description": ""
   },
-  "blocklatemessages.tooltip": {
-    "message": "Geplande berichten die voorbij hun geplande tijd zijn vertraagd, bijvoorbeeld omdat Thunderbird niet actief was, niet afleveren",
+  "close.label": {
+    "message": "Luk",
     "description": ""
   },
-  "editorbutton": {
-    "message": "Editor voor dynamische functies openen…",
+  "close.accesskey": {
+    "message": "L",
     "description": ""
   },
-  "editortip": {
-    "message": "Een venster openen voor het maken en bewerken van JavaScript-functies die complexe planningslogica implementeren.",
+  "close.cmdkey": {
+    "message": "w",
     "description": ""
   }
 }

--- a/_locales/de_DE/messages.json
+++ b/_locales/de_DE/messages.json
@@ -139,10 +139,6 @@
     "message": "wöchentlich",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Diese Werte als Defaultwerte speichern",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Benutzerhandbuch",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -164,11 +164,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "Η “Αποστολή” καθυστερεί κατά",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "λεπτά",
     "description": ""
   },
   "sendSundayLabel": {
@@ -365,6 +365,18 @@
   },
   "sendlatersendbutton.tooltip": {
     "message": "Με αυτή την επιλογή, η εντολή “Αποστολή” (είτε το κουμπί είτε ο συνδυασμός πλήκτρων Ctrl-Enter) μετατρέπεται σε “Αποστολή αργότερα”.",
+    "description": ""
+  },
+  "senddelay.tooltip": {
+    "message": "Ενεργοποιώντας την επιλογή, όλα τα μηνύματα που αποστέλλονται επιλέγοντας “Αποστολή” (είτε με το κουμπί είτε πατώντας Ctrl-Enter) καθυστερούν κατά τον καθορισμένο αριθμό λεπτών σε χρονοδρομολόγηση με Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "Καθώς γράφετε ένα μήνυμα μπορείτε πατώντας Ctrl-Alt-1, -2, or -3 να ενεργοποιήσετε τo πρώτο, δεύτερο ή τρίτο προκαθορισμένο κουμπί, εκτός αν ξετσεκάρετε την επιλογή, οπότε αυτοί οι συνδυασμεί πλήκτρων απενεργοποιούνται.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Ενεργοποίηση των συνδυασμών πλήκτρων για τις προκαθορισμένες επιλογές στο παράθυρο νέου μηνύματος",
     "description": ""
   },
   "contactauthor.tooltip": {
@@ -1073,6 +1085,10 @@
   },
   "DisabledMessage": {
     "message": "Απενεργοποιημένο",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "Έλεγχος",
     "description": ""
   }
 }

--- a/_locales/el_GR/messages.json
+++ b/_locales/el_GR/messages.json
@@ -139,10 +139,6 @@
     "message": "εβδομαδιαία",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Αποθήκευση αυτών των τιμών ως προεπιλεγμένων",
     "description": ""
@@ -164,11 +160,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "Η “Αποστολή” καθυστερεί κατά",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "λεπτά",
     "description": ""
   },
   "sendSundayLabel": {
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Οδηγίες χρήσης",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {
@@ -365,6 +353,18 @@
   },
   "sendlatersendbutton.tooltip": {
     "message": "Με αυτή την επιλογή, η εντολή “Αποστολή” (είτε το κουμπί είτε ο συνδυασμός πλήκτρων Ctrl-Enter) μετατρέπεται σε “Αποστολή αργότερα”.",
+    "description": ""
+  },
+  "senddelay.tooltip": {
+    "message": "Ενεργοποιώντας την επιλογή, όλα τα μηνύματα που αποστέλλονται επιλέγοντας “Αποστολή” (είτε με το κουμπί είτε πατώντας Ctrl-Enter) καθυστερούν κατά τον καθορισμένο αριθμό λεπτών σε χρονοδρομολόγηση με Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "Καθώς γράφετε ένα μήνυμα μπορείτε πατώντας Ctrl-Alt-1, -2, or -3 να ενεργοποιήσετε τo πρώτο, δεύτερο ή τρίτο προκαθορισμένο κουμπί, εκτός αν ξετσεκάρετε την επιλογή, οπότε αυτοί οι συνδυασμεί πλήκτρων απενεργοποιούνται.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Ενεργοποίηση των συνδυασμών πλήκτρων για τις προκαθορισμένες επιλογές στο παράθυρο νέου μηνύματος",
     "description": ""
   },
   "contactauthor.tooltip": {
@@ -1073,6 +1073,10 @@
   },
   "DisabledMessage": {
     "message": "Απενεργοποιημένο",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "Έλεγχος",
     "description": ""
   }
 }

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -395,6 +395,10 @@
     "message": "Donate",
     "description": ""
   },
+  "advancededitor.title": {
+    "message": "Advanced configuration editor",
+    "description": ""
+  },
   "editorlink.value": {
     "message": "Dynamic function editor",
     "description": ""

--- a/_locales/es_ES/messages.json
+++ b/_locales/es_ES/messages.json
@@ -139,10 +139,6 @@
     "message": "semanalmente",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Guardar estos valores como predeterminados",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Guía de usuario",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -168,7 +168,7 @@
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minuutti",
+    "message": "minuutilla",
     "description": ""
   },
   "sendSundayLabel": {
@@ -376,7 +376,7 @@
     "description": ""
   },
   "composewindowhotkeys.caption": {
-    "message": "Salli viestinkirjoituksessa mukautetut näppäinkomennot",
+    "message": "Salli esiasetettujen näppäinkommentojen käyttö viestinkirjoituksessa",
     "description": ""
   },
   "contactauthor.tooltip": {
@@ -624,7 +624,7 @@
     "description": ""
   },
   "January": {
-    "message": "tammikuu",
+    "message": "Tammikuu",
     "description": ""
   },
   "February": {
@@ -684,7 +684,7 @@
     "description": ""
   },
   "CopyUnsentError": {
-    "message": "Lähetä myöhemmin: Virhe kopioidessa ajastettua viestiä Lähtevät-kansioon lähetettäväksi (code $1). Lähetä myöhemmin -laajennuksen käyttö on poistettu käytöstä! Katso https://blog.kamens.us/send-later/#outbox-copy-failure.",
+    "message": "Lähetä myöhemmin: Virhe kopioidessa ajastettua viestiä Lähtevät-kansioon lähetettäväksi (code $1). Lähetä myöhemmin -laajennus on poistettu käytöstä! Katso https://blog.kamens.us/send-later/#outbox-copy-failure.",
     "description": ""
   },
   "CopyRecurError": {
@@ -692,11 +692,11 @@
     "description": ""
   },
   "CorruptFolderError": {
-    "message": "Lähetä myöhemmin: Kansio $1 saattaa olla viallinen. Avaa kansion Ominaisuudet ja käynnistä ”Korjaa kansio” -toiminto. Katso https://blog.kamens.us/send-later/#corrupt-drafts-error.",
+    "message": "Lähetä myöhemmin: Kansio $1 saattaa olla viallinen. Avaa kansion \"Ominaisuudet\" -välilehti ja käynnistä ”Korjaa kansio” -toiminto. Katso https://blog.kamens.us/send-later/#corrupt-drafts-error.",
     "description": ""
   },
   "MessageResendError": {
-    "message": "Lähetä myöhemmin: Yritetäänkö lähettää uudelleen jo kerran lähetettyä viestiä?! Lähtevät tai Luonnokset $1 -kansiosi on luultavasti vialllinen. Korjaa ne seuraavassa kuvatulla tavalla: https://blog.kamens.us/send-later/#corrupt-outbox.",
+    "message": "Lähetä myöhemmin: Yritätkö lähettää uudelleen jo kerran lähetetyn viestin?! \"Lähtevät\" tai \"Luonnokset\" $1 -kansiosi on luultavasti vialllinen. Korjaa vika linkissä kuvatulla tavalla: https://blog.kamens.us/send-later/#corrupt-outbox.",
     "description": ""
   },
   "minutely": {
@@ -720,7 +720,7 @@
     "description": ""
   },
   "plural_minutely": {
-    "message": "minuutti",
+    "message": "minuutteitain",
     "description": ""
   },
   "plural_daily": {
@@ -740,7 +740,7 @@
     "description": ""
   },
   "every_minutely": {
-    "message": "joka $1. minuutti",
+    "message": "joka $1. minuuttia",
     "description": ""
   },
   "every_daily": {
@@ -760,7 +760,7 @@
     "description": ""
   },
   "everyempty": {
-    "message": "tietty päivä kuukauden tietyllä viikolla",
+    "message": "joka kuukauden tietyn viikon viikkopäivänä",
     "description": ""
   },
   "everymonthly": {
@@ -884,7 +884,7 @@
     "description": ""
   },
   "draftSaveWarning": {
-    "message": "VAROITUS: Jotta Lähetä myöhemmin ei lähettäisi viestiä kun olet muokkaamassa sitä, sen ajastettu lähetys on peruttu.\nOle hyvä ja ajasta viestin lähetys uudestaan, kun olet saanut valmiiksi sen muokkaamisen.",
+    "message": "VAROITUS: Jotta Lähetä myöhemmin ei lähettäisi viestiä kun olet muokkaamassa sitä, sen ajastettu lähetys on peruttu.\nOle hyvä ja ajasta viestin lähetys uudelleen, kun olet saanut sen valmiiksi.",
     "description": ""
   },
   "AreYouSure": {
@@ -1080,7 +1080,7 @@
     "description": ""
   },
   "IdleMessage": {
-    "message": "TOIMETON",
+    "message": "Ei ajastettuja viestejä",
     "description": ""
   },
   "DisabledMessage": {

--- a/_locales/fi_FI/messages.json
+++ b/_locales/fi_FI/messages.json
@@ -139,10 +139,6 @@
     "message": "viikoittain",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Tallenna oletusarvoiksi",
     "description": ""
@@ -168,7 +164,7 @@
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minuutti",
+    "message": "minuutilla",
     "description": ""
   },
   "sendSundayLabel": {
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Käyttäjän opas",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {
@@ -376,7 +364,7 @@
     "description": ""
   },
   "composewindowhotkeys.caption": {
-    "message": "Salli viestinkirjoituksessa mukautetut näppäinkomennot",
+    "message": "Salli esiasetettujen näppäinkommentojen käyttö viestinkirjoituksessa",
     "description": ""
   },
   "contactauthor.tooltip": {
@@ -624,7 +612,7 @@
     "description": ""
   },
   "January": {
-    "message": "tammikuu",
+    "message": "Tammikuu",
     "description": ""
   },
   "February": {
@@ -684,7 +672,7 @@
     "description": ""
   },
   "CopyUnsentError": {
-    "message": "Lähetä myöhemmin: Virhe kopioidessa ajastettua viestiä Lähtevät-kansioon lähetettäväksi (code $1). Lähetä myöhemmin -laajennuksen käyttö on poistettu käytöstä! Katso https://blog.kamens.us/send-later/#outbox-copy-failure.",
+    "message": "Lähetä myöhemmin: Virhe kopioidessa ajastettua viestiä Lähtevät-kansioon lähetettäväksi (code $1). Lähetä myöhemmin -laajennus on poistettu käytöstä! Katso https://blog.kamens.us/send-later/#outbox-copy-failure.",
     "description": ""
   },
   "CopyRecurError": {
@@ -692,11 +680,11 @@
     "description": ""
   },
   "CorruptFolderError": {
-    "message": "Lähetä myöhemmin: Kansio $1 saattaa olla viallinen. Avaa kansion Ominaisuudet ja käynnistä ”Korjaa kansio” -toiminto. Katso https://blog.kamens.us/send-later/#corrupt-drafts-error.",
+    "message": "Lähetä myöhemmin: Kansio $1 saattaa olla viallinen. Avaa kansion \"Ominaisuudet\" -välilehti ja käynnistä ”Korjaa kansio” -toiminto. Katso https://blog.kamens.us/send-later/#corrupt-drafts-error.",
     "description": ""
   },
   "MessageResendError": {
-    "message": "Lähetä myöhemmin: Yritetäänkö lähettää uudelleen jo kerran lähetettyä viestiä?! Lähtevät tai Luonnokset $1 -kansiosi on luultavasti vialllinen. Korjaa ne seuraavassa kuvatulla tavalla: https://blog.kamens.us/send-later/#corrupt-outbox.",
+    "message": "Lähetä myöhemmin: Yritätkö lähettää uudelleen jo kerran lähetetyn viestin?! \"Lähtevät\" tai \"Luonnokset\" $1 -kansiosi on luultavasti vialllinen. Korjaa vika linkissä kuvatulla tavalla: https://blog.kamens.us/send-later/#corrupt-outbox.",
     "description": ""
   },
   "minutely": {
@@ -720,7 +708,7 @@
     "description": ""
   },
   "plural_minutely": {
-    "message": "minuutti",
+    "message": "minuutteitain",
     "description": ""
   },
   "plural_daily": {
@@ -740,7 +728,7 @@
     "description": ""
   },
   "every_minutely": {
-    "message": "joka $1. minuutti",
+    "message": "joka $1. minuuttia",
     "description": ""
   },
   "every_daily": {
@@ -760,7 +748,7 @@
     "description": ""
   },
   "everyempty": {
-    "message": "tietty päivä kuukauden tietyllä viikolla",
+    "message": "joka kuukauden tietyn viikon viikkopäivänä",
     "description": ""
   },
   "everymonthly": {
@@ -884,7 +872,7 @@
     "description": ""
   },
   "draftSaveWarning": {
-    "message": "VAROITUS: Jotta Lähetä myöhemmin ei lähettäisi viestiä kun olet muokkaamassa sitä, sen ajastettu lähetys on peruttu.\nOle hyvä ja ajasta viestin lähetys uudestaan, kun olet saanut valmiiksi sen muokkaamisen.",
+    "message": "VAROITUS: Jotta Lähetä myöhemmin ei lähettäisi viestiä kun olet muokkaamassa sitä, sen ajastettu lähetys on peruttu.\nOle hyvä ja ajasta viestin lähetys uudelleen, kun olet saanut sen valmiiksi.",
     "description": ""
   },
   "AreYouSure": {
@@ -1080,7 +1068,7 @@
     "description": ""
   },
   "IdleMessage": {
-    "message": "TOIMETON",
+    "message": "Ei ajastettuja viestejä",
     "description": ""
   },
   "DisabledMessage": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -160,7 +160,7 @@
     "description": ""
   },
   "sendButtonPrefLabel": {
-    "message": "Remplacer « Envoyer » par « Envoyer Plus Tard »",
+    "message": "« Envoyer » exécute « Envoyer Plus Tard »",
     "description": ""
   },
   "sendDelayPrefLabel1": {

--- a/_locales/fr_FR/messages.json
+++ b/_locales/fr_FR/messages.json
@@ -139,10 +139,6 @@
     "message": "hebdomadaire",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Enregistrer ces valeurs comme « valeurs par défaut »",
     "description": ""
@@ -160,7 +156,7 @@
     "description": ""
   },
   "sendButtonPrefLabel": {
-    "message": "Remplacer « Envoyer » par « Envoyer Plus Tard »",
+    "message": "« Envoyer » exécute « Envoyer Plus Tard »",
     "description": ""
   },
   "sendDelayPrefLabel1": {
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Guide de l'utilisateur",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/gl/messages.json
+++ b/_locales/gl/messages.json
@@ -60,11 +60,11 @@
     "description": ""
   },
   "logLevelAll": {
-    "message": "All",
+    "message": "Todos",
     "description": ""
   },
   "logLevelDebug": {
-    "message": "Debug",
+    "message": "Depuración",
     "description": ""
   },
   "logLevelError": {
@@ -72,19 +72,19 @@
     "description": ""
   },
   "logLevelFatal": {
-    "message": "Fatal",
+    "message": "Crítico",
     "description": ""
   },
   "logLevelInfo": {
-    "message": "Info",
+    "message": "Información",
     "description": ""
   },
   "logLevelTrace": {
-    "message": "Trace",
+    "message": "Rastreo",
     "description": ""
   },
   "logLevelWarn": {
-    "message": "Warn",
+    "message": "Aviso",
     "description": ""
   },
   "markReadPrefLabel": {
@@ -164,11 +164,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "“Enviar” atrasa as mensaxes de",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "minutos",
     "description": ""
   },
   "sendSundayLabel": {
@@ -295,6 +295,10 @@
     "message": "Enviar máis tarde",
     "description": ""
   },
+  "sendlater.toolbar.sendlater.button.tooltip": {
+    "message": "Activa Send Later para programar unha mensaxe despois de introducir a data de envío desexada na caixa de texto. Este botón non fai nada por si só; hai que engadir tamén a caixa de texto ou os seleccionadores de data/hora (non compatibles con todas as versións de Thunderbird) á barra de ferramentas para que este botón sexa útil.",
+    "description": ""
+  },
   "sendlater.toolbar.textbox.emptytext": {
     "message": "hora de envío",
     "description": ""
@@ -363,6 +367,18 @@
     "message": "Con esta opción habilitada, o comando “Enviar” (tanto co botón coma premendo Ctrl+Intro) funciona igual que “Enviar máis tarde”.",
     "description": ""
   },
+  "senddelay.tooltip": {
+    "message": "Con esta opción habilitada, todas as mensaxes enviadas co comando “Enviar” (xa sexa pulsando o botón ou seleccionando Ctrl-Enter) atrasan o número de minutos especificado programados con Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "Ao escribir unha mensaxe, podes escribir Ctrl-Alt-1, -2 ou -3 para activar o primeiro, segundo ou terceiro botón preestablecido, a non ser que desmarques esta preferencia; nese caso estas ligazóns clave estarán desactivadas.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Habilitar atallos de teclas na ventá de redacción da mensaxe para predeterminados",
+    "description": ""
+  },
   "contactauthor.tooltip": {
     "message": "Envía unha mensaxe de correo ó autor de Send Later.",
     "description": ""
@@ -397,6 +413,10 @@
   },
   "editortip": {
     "message": "Abre unha fiestra para crear e editar funcións JavaScript que implementan unha lóxica de programación complexa.",
+    "description": ""
+  },
+  "loglevel.config": {
+    "message": "Configurar",
     "description": ""
   },
   "sendlater.ask.title.label": {
@@ -1065,6 +1085,10 @@
   },
   "DisabledMessage": {
     "message": "Desactivado",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "COMPROBANDO",
     "description": ""
   }
 }

--- a/_locales/gl_ES/messages.json
+++ b/_locales/gl_ES/messages.json
@@ -60,11 +60,11 @@
     "description": ""
   },
   "logLevelAll": {
-    "message": "All",
+    "message": "Todos",
     "description": ""
   },
   "logLevelDebug": {
-    "message": "Debug",
+    "message": "Depuración",
     "description": ""
   },
   "logLevelError": {
@@ -72,19 +72,19 @@
     "description": ""
   },
   "logLevelFatal": {
-    "message": "Fatal",
+    "message": "Crítico",
     "description": ""
   },
   "logLevelInfo": {
-    "message": "Info",
+    "message": "Información",
     "description": ""
   },
   "logLevelTrace": {
-    "message": "Trace",
+    "message": "Rastreo",
     "description": ""
   },
   "logLevelWarn": {
-    "message": "Warn",
+    "message": "Aviso",
     "description": ""
   },
   "markReadPrefLabel": {
@@ -139,10 +139,6 @@
     "message": "semanalmente",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Garda estes valores coma predeterminados",
     "description": ""
@@ -164,11 +160,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "“Enviar” atrasa as mensaxes de",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "minutos",
     "description": ""
   },
   "sendSundayLabel": {
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Guía do usuario",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {
@@ -293,6 +281,10 @@
   },
   "sendlater.toolbar.sendlater.button.label": {
     "message": "Enviar máis tarde",
+    "description": ""
+  },
+  "sendlater.toolbar.sendlater.button.tooltip": {
+    "message": "Activa Send Later para programar unha mensaxe despois de introducir a data de envío desexada na caixa de texto. Este botón non fai nada por si só; hai que engadir tamén a caixa de texto ou os seleccionadores de data/hora (non compatibles con todas as versións de Thunderbird) á barra de ferramentas para que este botón sexa útil.",
     "description": ""
   },
   "sendlater.toolbar.textbox.emptytext": {
@@ -363,6 +355,18 @@
     "message": "Con esta opción habilitada, o comando “Enviar” (tanto co botón coma premendo Ctrl+Intro) funciona igual que “Enviar máis tarde”.",
     "description": ""
   },
+  "senddelay.tooltip": {
+    "message": "Con esta opción habilitada, todas as mensaxes enviadas co comando “Enviar” (xa sexa pulsando o botón ou seleccionando Ctrl-Enter) atrasan o número de minutos especificado programados con Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "Ao escribir unha mensaxe, podes escribir Ctrl-Alt-1, -2 ou -3 para activar o primeiro, segundo ou terceiro botón preestablecido, a non ser que desmarques esta preferencia; nese caso estas ligazóns clave estarán desactivadas.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Habilitar atallos de teclas na ventá de redacción da mensaxe para predeterminados",
+    "description": ""
+  },
   "contactauthor.tooltip": {
     "message": "Envía unha mensaxe de correo ó autor de Send Later.",
     "description": ""
@@ -397,6 +401,10 @@
   },
   "editortip": {
     "message": "Abre unha fiestra para crear e editar funcións JavaScript que implementan unha lóxica de programación complexa.",
+    "description": ""
+  },
+  "loglevel.config": {
+    "message": "Configurar",
     "description": ""
   },
   "sendlater.ask.title.label": {
@@ -1065,6 +1073,10 @@
   },
   "DisabledMessage": {
     "message": "Desactivado",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "COMPROBANDO",
     "description": ""
   }
 }

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -295,6 +295,10 @@
     "message": "‫שלח מאוחר יותר‬",
     "description": ""
   },
+  "sendlater.toolbar.sendlater.button.tooltip": {
+    "message": "הפעל ‫שלח מאוחר יותר‬ לתזמן את משלוח ההודעה אחרי שהוגדר מועד המשלוח הרצוי בתיבת הטקסט. כפתור זה אינו מבצע כל פעולה כשלעצמו, עליכם להוסיף את תיבת הטקסט או את תאי בוחירת התאריך/הזמן לסרגל הכלים כדי שכפתור זה יהפוך לשימושי (לא נתמך בכל גרסאות 'ציפור הרעם').",
+    "description": ""
+  },
   "sendlater.toolbar.textbox.emptytext": {
     "message": "‫זמן המשלוח‬",
     "description": ""
@@ -1081,6 +1085,10 @@
   },
   "DisabledMessage": {
     "message": "‫נטרל פעולה‬",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "בודק",
     "description": ""
   }
 }

--- a/_locales/he_IL/messages.json
+++ b/_locales/he_IL/messages.json
@@ -139,10 +139,6 @@
     "message": "‫שבועי‬",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "שמור את הערכים הללו כברירת מחדל",
     "description": ""
@@ -227,14 +223,6 @@
     "message": "‫מדריך למשתמש‬",
     "description": ""
   },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
-    "description": ""
-  },
   "sendlater.prompt.sendlater.label": {
     "message": "‫העבר לתיבת דואר יוצא‬",
     "description": ""
@@ -293,6 +281,10 @@
   },
   "sendlater.toolbar.sendlater.button.label": {
     "message": "‫שלח מאוחר יותר‬",
+    "description": ""
+  },
+  "sendlater.toolbar.sendlater.button.tooltip": {
+    "message": "הפעל ‫שלח מאוחר יותר‬ לתזמן את משלוח ההודעה אחרי שהוגדר מועד המשלוח הרצוי בתיבת הטקסט. כפתור זה אינו מבצע כל פעולה כשלעצמו, עליכם להוסיף את תיבת הטקסט או את תאי בוחירת התאריך/הזמן לסרגל הכלים כדי שכפתור זה יהפוך לשימושי (לא נתמך בכל גרסאות 'ציפור הרעם').",
     "description": ""
   },
   "sendlater.toolbar.textbox.emptytext": {
@@ -1081,6 +1073,10 @@
   },
   "DisabledMessage": {
     "message": "‫נטרל פעולה‬",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "בודק",
     "description": ""
   }
 }

--- a/_locales/hu_HU/messages.json
+++ b/_locales/hu_HU/messages.json
@@ -139,10 +139,6 @@
     "message": "hetente",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Mentse ezeket az értékeket alapértelmezettként",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Felhasználói útmutató",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/hy_AM/messages.json
+++ b/_locales/hy_AM/messages.json
@@ -59,34 +59,6 @@
     "message": "Dump մատյանի աստիճանը՝",
     "description": ""
   },
-  "logLevelAll": {
-    "message": "All",
-    "description": ""
-  },
-  "logLevelDebug": {
-    "message": "Debug",
-    "description": ""
-  },
-  "logLevelError": {
-    "message": "Error",
-    "description": ""
-  },
-  "logLevelFatal": {
-    "message": "Fatal",
-    "description": ""
-  },
-  "logLevelInfo": {
-    "message": "Info",
-    "description": ""
-  },
-  "logLevelTrace": {
-    "message": "Trace",
-    "description": ""
-  },
-  "logLevelWarn": {
-    "message": "Warn",
-    "description": ""
-  },
   "markReadPrefLabel": {
     "message": "Նշել հերթագրված սևագրերը որպես ընթերցված",
     "description": ""
@@ -139,10 +111,6 @@
     "message": "շաբաթական",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Պահպանել որպես սկզբնադիր",
     "description": ""
@@ -161,14 +129,6 @@
   },
   "sendButtonPrefLabel": {
     "message": "«Ուղարկելը»-ը «Ուղարկել ավելի ուշ»-ն է",
-    "description": ""
-  },
-  "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
-    "description": ""
-  },
-  "sendDelayPrefLabel2": {
-    "message": "minutes",
     "description": ""
   },
   "sendSundayLabel": {
@@ -225,14 +185,6 @@
   },
   "userGuideLabel": {
     "message": "Օգտվողի ուղեցույցը",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/it_IT/messages.json
+++ b/_locales/it_IT/messages.json
@@ -139,10 +139,6 @@
     "message": "settimanale",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Salvare questi valori come predefiniti",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Manuale utente",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/ja_JP/messages.json
+++ b/_locales/ja_JP/messages.json
@@ -139,10 +139,6 @@
     "message": "毎週",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "デフォルトとして保存",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "ユーザーガイド",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -139,10 +139,6 @@
     "message": "ukentlig",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Lagre disse verdiene som standardverdier",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Bruksanvisning",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/nl_NL/messages.json
+++ b/_locales/nl_NL/messages.json
@@ -139,10 +139,6 @@
     "message": "wekelijks",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Deze waarden als de standaardwaarden opslaan",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Handleiding",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/pl_PL/messages.json
+++ b/_locales/pl_PL/messages.json
@@ -139,10 +139,6 @@
     "message": "co tydzień",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Zapisz te ustawienia jako domyślne",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Podręcznik użytkownika",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -60,15 +60,15 @@
     "description": ""
   },
   "logLevelAll": {
-    "message": "All",
+    "message": "Todos",
     "description": ""
   },
   "logLevelDebug": {
-    "message": "Debug",
+    "message": "Depuração de erros",
     "description": ""
   },
   "logLevelError": {
-    "message": "Error",
+    "message": "Erro",
     "description": ""
   },
   "logLevelFatal": {
@@ -76,15 +76,15 @@
     "description": ""
   },
   "logLevelInfo": {
-    "message": "Info",
+    "message": "Informação",
     "description": ""
   },
   "logLevelTrace": {
-    "message": "Trace",
+    "message": "Rastreio",
     "description": ""
   },
   "logLevelWarn": {
-    "message": "Warn",
+    "message": "Avisos",
     "description": ""
   },
   "markReadPrefLabel": {
@@ -164,11 +164,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "“Enviar” atrasa as mensagens em",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "minutos",
     "description": ""
   },
   "sendSundayLabel": {
@@ -296,7 +296,7 @@
     "description": ""
   },
   "sendlater.toolbar.sendlater.button.tooltip": {
-    "message": "Ative Send Later para agendar uma mensagem após inserir o tempo de envio desejado na caixa de texto. Este botão não faz nada por si; você também precisa adicionar a caixa de texto ou os seletores de data/hora (não suportado em todas as versões do Thunderbird) para a barra de ferramentas para que este botão seja útil.",
+    "message": "Ative Send Later para agendar uma mensagem após inserir o tempo de envio desejado na caixa de texto. Este botão não faz nada sozinho; também precisa adicionar a caixa de texto ou os seletores de data/hora (não suportado em todas as versões do Thunderbird) para a barra de ferramentas para que este botão seja útil.",
     "description": ""
   },
   "sendlater.toolbar.textbox.emptytext": {
@@ -365,6 +365,18 @@
   },
   "sendlatersendbutton.tooltip": {
     "message": "Com esta opção activa, o comando “Enviar” (através do botão ou pressionando Ctrl-Enter) actua da mesma forma que “Enviar mais tarde”.",
+    "description": ""
+  },
+  "senddelay.tooltip": {
+    "message": "Com esta opção ativada, todas as mensagens enviadas com o comando “Enviar” (tanto no botão com o atalho Ctrl-Enter) são atrasadas pelo número especificado de minutos com Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "Enquanto escreve uma mensagem, pode digitar Ctrl-Alt-1, -2, ou -3 para ativar o primeiro, segundo, ou terceiro botão predefinido, a menos que desmarque esta opção, nesse caso combinações de teclas estão desativadas.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Ativar combinações de teclas na janela de composição para predefinições",
     "description": ""
   },
   "contactauthor.tooltip": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -68,7 +68,7 @@
     "description": ""
   },
   "logLevelError": {
-    "message": "Error",
+    "message": "Erro",
     "description": ""
   },
   "logLevelFatal": {
@@ -84,7 +84,7 @@
     "description": ""
   },
   "logLevelWarn": {
-    "message": "Warn",
+    "message": "Aviso",
     "description": ""
   },
   "markReadPrefLabel": {
@@ -137,10 +137,6 @@
   },
   "recurWeeklyLabel": {
     "message": "semanalmente",
-    "description": ""
-  },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
     "description": ""
   },
   "saveDefaultsLabel": {
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Manual",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -60,15 +60,15 @@
     "description": ""
   },
   "logLevelAll": {
-    "message": "All",
+    "message": "Todos",
     "description": ""
   },
   "logLevelDebug": {
-    "message": "Debug",
+    "message": "Depuração de erros",
     "description": ""
   },
   "logLevelError": {
-    "message": "Error",
+    "message": "Erro",
     "description": ""
   },
   "logLevelFatal": {
@@ -76,15 +76,15 @@
     "description": ""
   },
   "logLevelInfo": {
-    "message": "Info",
+    "message": "Informação",
     "description": ""
   },
   "logLevelTrace": {
-    "message": "Trace",
+    "message": "Rastreio",
     "description": ""
   },
   "logLevelWarn": {
-    "message": "Warn",
+    "message": "Avisos",
     "description": ""
   },
   "markReadPrefLabel": {
@@ -139,10 +139,6 @@
     "message": "semanalmente",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Guardar estes valores como predefinidos",
     "description": ""
@@ -164,11 +160,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "“Enviar” atrasa as mensagens em",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "minutos",
     "description": ""
   },
   "sendSundayLabel": {
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Guia do utilizador",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {
@@ -296,7 +284,7 @@
     "description": ""
   },
   "sendlater.toolbar.sendlater.button.tooltip": {
-    "message": "Ative Send Later para agendar uma mensagem após inserir o tempo de envio desejado na caixa de texto. Este botão não faz nada por si; você também precisa adicionar a caixa de texto ou os seletores de data/hora (não suportado em todas as versões do Thunderbird) para a barra de ferramentas para que este botão seja útil.",
+    "message": "Ative Send Later para agendar uma mensagem após inserir o tempo de envio desejado na caixa de texto. Este botão não faz nada sozinho; também precisa adicionar a caixa de texto ou os seletores de data/hora (não suportado em todas as versões do Thunderbird) para a barra de ferramentas para que este botão seja útil.",
     "description": ""
   },
   "sendlater.toolbar.textbox.emptytext": {
@@ -365,6 +353,18 @@
   },
   "sendlatersendbutton.tooltip": {
     "message": "Com esta opção activa, o comando “Enviar” (através do botão ou pressionando Ctrl-Enter) actua da mesma forma que “Enviar mais tarde”.",
+    "description": ""
+  },
+  "senddelay.tooltip": {
+    "message": "Com esta opção ativada, todas as mensagens enviadas com o comando “Enviar” (tanto no botão com o atalho Ctrl-Enter) são atrasadas pelo número especificado de minutos com Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "Enquanto escreve uma mensagem, pode digitar Ctrl-Alt-1, -2, ou -3 para ativar o primeiro, segundo, ou terceiro botão predefinido, a menos que desmarque esta opção, nesse caso combinações de teclas estão desativadas.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Ativar combinações de teclas na janela de composição para predefinições",
     "description": ""
   },
   "contactauthor.tooltip": {

--- a/_locales/ro_RO/messages.json
+++ b/_locales/ro_RO/messages.json
@@ -139,10 +139,6 @@
     "message": "săptămânal",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Salvează ca valori implicite",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Ghidul utilizatorului",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -60,31 +60,31 @@
     "description": ""
   },
   "logLevelAll": {
-    "message": "All",
+    "message": "Все",
     "description": ""
   },
   "logLevelDebug": {
-    "message": "Debug",
+    "message": "Отладочные события",
     "description": ""
   },
   "logLevelError": {
-    "message": "Error",
+    "message": "Ошибки",
     "description": ""
   },
   "logLevelFatal": {
-    "message": "Fatal",
+    "message": "Фатальные ошибки",
     "description": ""
   },
   "logLevelInfo": {
-    "message": "Info",
+    "message": "Информация",
     "description": ""
   },
   "logLevelTrace": {
-    "message": "Trace",
+    "message": "Слежение",
     "description": ""
   },
   "logLevelWarn": {
-    "message": "Warn",
+    "message": "Предупреждения",
     "description": ""
   },
   "markReadPrefLabel": {
@@ -164,11 +164,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "«Отправить» откладывает сообщения на",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "мин.",
     "description": ""
   },
   "sendSundayLabel": {
@@ -295,6 +295,10 @@
     "message": "Отправить позже",
     "description": ""
   },
+  "sendlater.toolbar.sendlater.button.tooltip": {
+    "message": "Активируйте Send Later, чтобы запланировать сообщение после ввода желаемого времени отправки в текстовое поле. Эта кнопка ничего не делает сама по себе; вам также нужно добавить текстовое поле или поле выбора даты/времени (поддерживается не во всех версиях Thunderbird) на панель инструментов, чтобы эта кнопка была полезной.",
+    "description": ""
+  },
   "sendlater.toolbar.textbox.emptytext": {
     "message": "время отправки",
     "description": ""
@@ -363,6 +367,18 @@
     "message": "Когда эта опция активна, то команда «Отправить» (и кнопка и нажатие на Ctrl-Enter) выполняется так же как и «Отправить позже».",
     "description": ""
   },
+  "senddelay.tooltip": {
+    "message": "Если эта опция включена, все сообщения, отправленные с помощью команды «Отправить» (либо кнопки, либо сочетания клавиш Ctrl-Enter), откладываются на указанное количество минут, запланированных с помощью Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "При написании сообщения вы можете нажать Ctrl-Alt-1, -2 или -3 для активации первой, второй, или третьей предустановленной кнопки, если вы не сняли флажок с этой настройки, в этом случае эти сочетания клавиш отключены.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Включить привязку клавиш для предустановок в окне сообщения",
+    "description": ""
+  },
   "contactauthor.tooltip": {
     "message": "Написать письмо автору Send Later.",
     "description": ""
@@ -397,6 +413,10 @@
   },
   "editortip": {
     "message": "Открыть окно для создания и редактирования JavaScript функций, реализующих сложную логику планирования.",
+    "description": ""
+  },
+  "loglevel.config": {
+    "message": "Настройки",
     "description": ""
   },
   "sendlater.ask.title.label": {
@@ -1020,7 +1040,7 @@
     "description": ""
   },
   "ImportError": {
-    "message": "Импорт ошибок",
+    "message": "Ошибка импорта",
     "description": ""
   },
   "ExportTitle": {
@@ -1065,6 +1085,10 @@
   },
   "DisabledMessage": {
     "message": "ОТКЛЮЧЕНО",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "ПРОВЕРКА",
     "description": ""
   }
 }

--- a/_locales/ru_RU/messages.json
+++ b/_locales/ru_RU/messages.json
@@ -60,31 +60,31 @@
     "description": ""
   },
   "logLevelAll": {
-    "message": "All",
+    "message": "Все",
     "description": ""
   },
   "logLevelDebug": {
-    "message": "Debug",
+    "message": "Отладочные события",
     "description": ""
   },
   "logLevelError": {
-    "message": "Error",
+    "message": "Ошибки",
     "description": ""
   },
   "logLevelFatal": {
-    "message": "Fatal",
+    "message": "Фатальные ошибки",
     "description": ""
   },
   "logLevelInfo": {
-    "message": "Info",
+    "message": "Информация",
     "description": ""
   },
   "logLevelTrace": {
-    "message": "Trace",
+    "message": "Слежение",
     "description": ""
   },
   "logLevelWarn": {
-    "message": "Warn",
+    "message": "Предупреждения",
     "description": ""
   },
   "markReadPrefLabel": {
@@ -139,10 +139,6 @@
     "message": "еженедельно",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Сохранить эти значения по умолчанию",
     "description": ""
@@ -164,11 +160,11 @@
     "description": ""
   },
   "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
+    "message": "«Отправить» откладывает сообщения на",
     "description": ""
   },
   "sendDelayPrefLabel2": {
-    "message": "minutes",
+    "message": "мин.",
     "description": ""
   },
   "sendSundayLabel": {
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Руководство Пользователя",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {
@@ -293,6 +281,10 @@
   },
   "sendlater.toolbar.sendlater.button.label": {
     "message": "Отправить позже",
+    "description": ""
+  },
+  "sendlater.toolbar.sendlater.button.tooltip": {
+    "message": "Активируйте Send Later, чтобы запланировать сообщение после ввода желаемого времени отправки в текстовое поле. Эта кнопка ничего не делает сама по себе; вам также нужно добавить текстовое поле или поле выбора даты/времени (поддерживается не во всех версиях Thunderbird) на панель инструментов, чтобы эта кнопка была полезной.",
     "description": ""
   },
   "sendlater.toolbar.textbox.emptytext": {
@@ -363,6 +355,18 @@
     "message": "Когда эта опция активна, то команда «Отправить» (и кнопка и нажатие на Ctrl-Enter) выполняется так же как и «Отправить позже».",
     "description": ""
   },
+  "senddelay.tooltip": {
+    "message": "Если эта опция включена, все сообщения, отправленные с помощью команды «Отправить» (либо кнопки, либо сочетания клавиш Ctrl-Enter), откладываются на указанное количество минут, запланированных с помощью Send Later.",
+    "description": ""
+  },
+  "composewindowhotkeys.tooltip": {
+    "message": "При написании сообщения вы можете нажать Ctrl-Alt-1, -2 или -3 для активации первой, второй, или третьей предустановленной кнопки, если вы не сняли флажок с этой настройки, в этом случае эти сочетания клавиш отключены.",
+    "description": ""
+  },
+  "composewindowhotkeys.caption": {
+    "message": "Включить привязку клавиш для предустановок в окне сообщения",
+    "description": ""
+  },
   "contactauthor.tooltip": {
     "message": "Написать письмо автору Send Later.",
     "description": ""
@@ -397,6 +401,10 @@
   },
   "editortip": {
     "message": "Открыть окно для создания и редактирования JavaScript функций, реализующих сложную логику планирования.",
+    "description": ""
+  },
+  "loglevel.config": {
+    "message": "Настройки",
     "description": ""
   },
   "sendlater.ask.title.label": {
@@ -1020,7 +1028,7 @@
     "description": ""
   },
   "ImportError": {
-    "message": "Импорт ошибок",
+    "message": "Ошибка импорта",
     "description": ""
   },
   "ExportTitle": {
@@ -1065,6 +1073,10 @@
   },
   "DisabledMessage": {
     "message": "ОТКЛЮЧЕНО",
+    "description": ""
+  },
+  "CheckingMessage": {
+    "message": "ПРОВЕРКА",
     "description": ""
   }
 }

--- a/_locales/sv_SE/messages.json
+++ b/_locales/sv_SE/messages.json
@@ -139,10 +139,6 @@
     "message": "varje vecka",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Spara dessa värden som standardvärden",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "Användarhandbok",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/tr_TR/messages.json
+++ b/_locales/tr_TR/messages.json
@@ -1,110 +1,6 @@
 {
-  "extensionName": {
-    "message": "Send Later",
-    "description": "The name of the add-on, displayed in various places."
-  },
-  "extensionDescription": {
-    "message": "True \"Send Later\" functionality to schedule the time for sending an email.",
-    "description": "A short description of the add-on."
-  },
-  "advancedOptionsTitle": {
-    "message": "Advanced",
-    "description": ""
-  },
-  "altBindingPrefLabel": {
-    "message": "Bind Alt-Shift-Enter instead of Ctrl-Shift-Enter",
-    "description": ""
-  },
-  "blockLateMessagesPrefLabel1": {
-    "message": "Don't deliver messages more than",
-    "description": ""
-  },
-  "blockLateMessagesPrefLabel2": {
-    "message": "minutes late",
-    "description": ""
-  },
-  "cancelLabel": {
-    "message": "Cancel",
-    "description": ""
-  },
-  "checkTimePrefLabel1": {
-    "message": "Check every",
-    "description": ""
-  },
-  "checkTimePrefLabel2": {
-    "message": "minutes",
-    "description": ""
-  },
   "clearDefaultsLabel": {
     "message": "Varsayılanları temizle",
-    "description": ""
-  },
-  "contactAuthorLabel": {
-    "message": "Contact Maintainer",
-    "description": ""
-  },
-  "enforceRestrictionsPrefLabel": {
-    "message": "Enforce time and day restrictions at delivery time",
-    "description": ""
-  },
-  "generalOptionsTitle": {
-    "message": "General Options",
-    "description": ""
-  },
-  "logConsoleLevelLabel": {
-    "message": "Console log level",
-    "description": ""
-  },
-  "logDumpLevelLabel": {
-    "message": "File log level",
-    "description": ""
-  },
-  "logLevelAll": {
-    "message": "All",
-    "description": ""
-  },
-  "logLevelDebug": {
-    "message": "Debug",
-    "description": ""
-  },
-  "logLevelError": {
-    "message": "Error",
-    "description": ""
-  },
-  "logLevelFatal": {
-    "message": "Fatal",
-    "description": ""
-  },
-  "logLevelInfo": {
-    "message": "Info",
-    "description": ""
-  },
-  "logLevelTrace": {
-    "message": "Trace",
-    "description": ""
-  },
-  "logLevelWarn": {
-    "message": "Warn",
-    "description": ""
-  },
-  "markReadPrefLabel": {
-    "message": "Mark scheduled drafts as read",
-    "description": ""
-  },
-  "quickOptionsLabel1Label": {
-    "message": "Shortcut 1 label",
-    "description": ""
-  },
-  "quickOptionsLabel2Label": {
-    "message": "Shortcut 2 label",
-    "description": ""
-  },
-  "quickOptionsLabel3Label": {
-    "message": "Shortcut 3 label",
-    "description": ""
-  },
-  "quickOptionsValueLabel": {
-    "message": "quickOptionsValueLabel",
     "description": ""
   },
   "recurAnnuallyLabel": {
@@ -113,14 +9,6 @@
   },
   "recurDailyLabel": {
     "message": "günlük",
-    "description": ""
-  },
-  "recurFunctionLabel": {
-    "message": "Function",
-    "description": ""
-  },
-  "recurLabel": {
-    "message": "Recur",
     "description": ""
   },
   "recurMinutelyLabel": {
@@ -139,36 +27,12 @@
     "message": "haftalık",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "Bu değerleri varsayılan olarak kaydet",
     "description": ""
   },
-  "sendAtDefaultLabel": {
-    "message": "Enter a date above",
-    "description": "Displayed in place of send at time before user makes selections"
-  },
-  "sendAtLabel": {
-    "message": "Send at",
-    "description": ""
-  },
   "sendBtwnLabel": {
     "message": "Arasında",
-    "description": ""
-  },
-  "sendButtonPrefLabel": {
-    "message": "\"Send\" does \"Send later\"",
-    "description": ""
-  },
-  "sendDelayPrefLabel1": {
-    "message": "\"Send\" delays messages by",
-    "description": ""
-  },
-  "sendDelayPrefLabel2": {
-    "message": "minutes",
     "description": ""
   },
   "sendSundayLabel": {
@@ -199,40 +63,8 @@
     "message": "Cumartesi",
     "description": ""
   },
-  "sendNowLabel": {
-    "message": "Send now",
-    "description": ""
-  },
   "sendOnlyOnLabel": {
     "message": "Yalnızca",
-    "description": ""
-  },
-  "sendUnsentMessagesPrefLabel": {
-    "message": "Trigger unsent message delivery from outbox",
-    "description": ""
-  },
-  "showColumnPrefLabel": {
-    "message": "Show Send Later column",
-    "description": ""
-  },
-  "showHeaderPrefLabel": {
-    "message": "Show Send Later header",
-    "description": ""
-  },
-  "showStatusPrefLabel": {
-    "message": "Show Send Later in status bar",
-    "description": ""
-  },
-  "userGuideLabel": {
-    "message": "Website",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.calculate.label": {

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -139,10 +139,6 @@
     "message": "每周",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "将这些数值保存为默认",
     "description": ""
@@ -225,14 +221,6 @@
   },
   "userGuideLabel": {
     "message": "用户指南",
-    "description": ""
-  },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
     "description": ""
   },
   "sendlater.prompt.sendlater.label": {

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -139,10 +139,6 @@
     "message": "每週",
     "description": ""
   },
-  "resetPrefsButton": {
-    "message": "Reset Preferences",
-    "description": ""
-  },
   "saveDefaultsLabel": {
     "message": "將這些設成預設值",
     "description": ""
@@ -227,14 +223,6 @@
     "message": "使用說明",
     "description": ""
   },
-  "errorDateInPast": {
-    "message": "Selected date is in the past",
-    "description": ""
-  },
-  "DelayFunctionHelp": {
-    "message": "Simply delay message by some number of minutes. First argument is taken as the delay time.",
-    "description": ""
-  },
   "sendlater.prompt.sendlater.label": {
     "message": "存至寄件匣",
     "description": ""
@@ -293,6 +281,10 @@
   },
   "sendlater.toolbar.sendlater.button.label": {
     "message": "延期發信",
+    "description": ""
+  },
+  "sendlater.toolbar.sendlater.button.tooltip": {
+    "message": "在文本框中輸入想要發送的時間之後激活 延期發信 安排發送消息。此按鈕本身沒有任何作用；您還需要將文本框或日期/時間選擇器(並非在所有 Thunderbird 版本中支持) 添加到工具欄，以使此按鈕有用。",
     "description": ""
   },
   "sendlater.toolbar.textbox.emptytext": {


### PR DESCRIPTION
Merge locale changes from 7.x branch, drop default english translations, and update migration script to automatically replace &quot; with unicode quote characters.