### PR TITLE
Need to set Send Later column status properly on Thunderbird startup

### DIFF
--- a/experiments/headerView.js
+++ b/experiments/headerView.js
@@ -413,6 +413,8 @@ var SendLaterHeaderView = {
     Services.obs.addObserver(this.columnHandlerObserver, "MsgCreateDBView", false);
     document.getElementById("folderTree").addEventListener(
       "select", this.hideShowColumn.bind(this), false);
+    // onLoad may have run when a folder is already being displayed.
+    try { this.hideShowColumn(); } catch (ex) { /* or maybe not */ }
     AddonManager.addAddonListener(this.AddonListener);
     SLStatic.debug("Leaving function","SendLaterHeaderView.onLoad");
   },


### PR DESCRIPTION
When the code for initializing the Send Later column and header
handlers runs when Send Later starts up, it isn't guaranteed to run
before the folder display has already been initialized, so we need to
check if a folder is already being displayed, and if so, then set the
Send Later column properly for that folder.