### PR TITLE
Prefer the future when parsing a date/time entered by hand

### DIFF
--- a/ui/popup.js
+++ b/ui/popup.js
@@ -479,7 +479,9 @@ const SLPopup = {
         }
       } else if (evt.target.id === "send-datetime") {
         const localeCode = browser.i18n.getUILanguage();
-        const sendAtDate = Sugar.Date.create(dom["send-datetime"].value, localeCode);
+        const sendAtDate = Sugar.Date.create(dom["send-datetime"].value,
+                                             {locale: localeCode,
+                                              future: true});
         try {
           const sendAt = new Sugar.Date(sendAtDate);
           dom["send-date"].value = sendAt.format('%Y-%m-%d');


### PR DESCRIPTION
When the user is using the text box to schedule a message rather than
the date and time pickers, prefer future times when what is entered is
ambiguous. This way, for example, if the user enters "10:00" and it's
later than that in the day, the next day is chosen instead of a time
in the past. This restores the behavior of the TB68 version of Send
Later.