### PR TITLE
Also load drafts column contents for currently open window

### DIFF
--- a/experiments/headerView.js
+++ b/experiments/headerView.js
@@ -414,7 +414,10 @@ var SendLaterHeaderView = {
     document.getElementById("folderTree").addEventListener(
       "select", this.hideShowColumn.bind(this), false);
     // onLoad may have run when a folder is already being displayed.
-    try { this.hideShowColumn(); } catch (ex) { /* or maybe not */ }
+    try {
+      this.hideShowColumn();
+      this.columnHandlerObserver.observe();
+    } catch (ex) { /* or maybe not */ console.warn(ex); }
     AddonManager.addAddonListener(this.AddonListener);
     SLStatic.debug("Leaving function","SendLaterHeaderView.onLoad");
   },


### PR DESCRIPTION
If the currently open window happens to be on the Drafts folder, make sure that its column is not only visible, but that the contents are populated.