### PR TITLE
Be more aggressive about opening the composition window toolbar.

### DIFF
--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -1093,6 +1093,7 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
                   const { document } = window;
                   const toolbarId = "composeToolbar2";
                   const toolbar = document.getElementById(toolbarId);
+
                   const widgetId = ExtensionCommon.makeWidgetId(extension.id);
                   const toolbarButtonId = `${widgetId}-composeAction-toolbarbutton`;
                   const windowURL =
@@ -1121,6 +1122,16 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
                     );
                     // Services.xulStore.persist(toolbar, "currentset");
                   }
+
+                  Services.xulStore.setValue(
+                    windowURL,
+                    toolbarId,
+                    "collapsed",
+                    "false"
+                  );
+                  toolbar.collapsed = false;
+                  toolbar.hidden = false;
+
                   console.debug("Compose window has send later button now.");
                 } catch (err) {
                   console.error("Error enabling toolbar button", err);


### PR DESCRIPTION
As the title says. Not only ensure that Send Later is added to the toolbar, but make sure the toolbar itself is visible.