### PR TITLE
Improve the scheduler interface

### DIFF
--- a/background.js
+++ b/background.js
@@ -900,7 +900,6 @@ browser.runtime.onMessage.addListener(async (message) => {
     case "doSendNow": {
       SLStatic.debug("User requested send immediately.");
       if (!window.navigator.onLine) {
-        // TODO -> Option to place in outbox.
         SendLater.notify("Thunderbird is offline.",
                         "Cannot send message at this time.");
       } else {
@@ -909,6 +908,14 @@ browser.runtime.onMessage.addListener(async (message) => {
           setTimeout(() => delete SendLater.composeState[message.tabId], 1000);
         });
       }
+      break;
+    }
+    case "doPlaceInOutbox": {
+      SLStatic.debug("User requested system send later.");
+      SendLater.composeState[message.tabId] = "sending";
+      browser.SL3U.builtInSendLater().then(()=>{
+        setTimeout(() => delete SendLater.composeState[message.tabId], 1000);
+      });
       break;
     }
     case "doSendLater": {

--- a/background.js
+++ b/background.js
@@ -918,6 +918,10 @@ browser.runtime.onMessage.addListener(async (message) => {
       });
       break;
     }
+    case "getMainLoopStatus": {
+      response.previousLoop = SLStatic.previousLoop.getTime();
+      break;
+    }
     case "doSendLater": {
       SLStatic.debug("User requested send later.");
       if (SendLater.composeState[message.tabId] === "scheduling" ||

--- a/ui/popup.html
+++ b/ui/popup.html
@@ -9,10 +9,11 @@
     <section style="display:block;" id="sendAtTimeDateDiv">
       <div class="div-table">
         <div class="div-table-row">
-          <div class="div-table-cell localized __MSG_sendAtLabel__">
+          <div class="div-table-cell localized __MSG_sendAtLabel__"
+                style="white-space: nowrap">
             Send at
           </div>
-          <div class="div-table-cell">
+          <div class="div-table-cell" style="width:100%">
             <input id="send-datetime" type="text" style="width:100%"
               class="localized __MSG_sendAtDefaultLabel__"/>
           </div>
@@ -84,14 +85,14 @@
               <input type="radio" name="monthly-recur-type" style="margin-left:1em;"
                   id='recur-monthly-byweek' value='recur-byweek'/>
               <span class="localized __MSG_sendlater.prompt.every.label__">Every</span>
-              <select id="recur-monthly-byweek-week">
+              <select id="recur-monthly-byweek-week" style="margin:0.15em;">
                 <option value="1" class="option-label localized __MSG_ord1__">1st</option>
                 <option value="2" class="option-label localized __MSG_ord2__">2nd</option>
                 <option value="3" class="option-label localized __MSG_ord3__">3rd</option>
                 <option value="4" class="option-label localized __MSG_ord4__">4th</option>
                 <option value="5" class="option-label localized __MSG_ord5__">5th</option>
               </select>
-              <select id="recur-monthly-byweek-day">
+              <select id="recur-monthly-byweek-day" style="margin:0.15em;">
                 <option value="0" class="option-label localized __MSG_everymonthly_day0__">Sunday</option>
                 <option value="1" class="option-label localized __MSG_everymonthly_day1__">Monday</option>
                 <option value="2" class="option-label localized __MSG_everymonthly_day2__">Tuesday</option>
@@ -205,11 +206,6 @@
       <table style="width:100%">
         <tr>
           <td>
-          <input type="button" value="Send Now" id="sendNow"
-            class="localized __MSG_sendNowLabel__"
-            style="margin:0 2.5%;width:95%;" class="delayButton"/>
-          </td>
-          <td>
           <input type="button" value="in 15 minutes" id="quick-opt-1"
             style="width:100%;" class="delayButton" />
           </td>
@@ -223,16 +219,21 @@
           </td>
         </tr>
       </table>
+      <table style="width:100%;float:center;">
+        <tr>
+          <td>
+          <input type="button" value="Send Now" id="sendNow"
+            class="localized __MSG_sendNowLabel__"
+            style="margin:0 2.5%;width:95%;" class="delayButton"/>
+          </td>
+          <td>
+            <input type="button" value="Put in Outbox" id="placeInOutbox"
+              class="localized __MSG_sendlater.prompt.sendlater.label__"
+              style="margin:0 2.5%;width:95%;" class="delayButton"/>
+            </td>
+        </tr>
+      </table>
     </section>
-
-    <!--
-    <section style="clear:both;display:block;">
-      <input type="button" value="Send Now" id="sendNow"
-        class="localized __MSG_sendNowLabel__"/>
-      <input type="button" value="Cancel" id="cancel"
-        class="localized __MSG_cancelLabel__"/>
-    </section>
-    -->
 
     <script type="text/javascript" src="/utils/sugar-custom.js"></script>
     <script type="text/javascript" src="/utils/static.js"></script>

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -21,7 +21,7 @@ const SLPopup = {
   doSendWithSchedule(schedule) {
     if (schedule && !schedule.err) {
       const message = {
-        tabId: this.tabId,
+        tabId: SLPopup.tabId,
         action: "doSendLater",
         sendAt: schedule.sendAt,
         recurSpec: SLStatic.unparseRecurSpec(schedule.recur),
@@ -36,7 +36,7 @@ const SLPopup = {
 
   doSendNow() {
     const message = {
-      tabId: this.tabId,
+      tabId: SLPopup.tabId,
       action: "doSendNow"
     };
     SLStatic.debug(message);
@@ -101,7 +101,7 @@ const SLPopup = {
       }
     }
 
-    const body = this.ufuncs[funcName].body;
+    const body = SLPopup.ufuncs[funcName].body;
 
     const { sendAt, nextspec, nextargs, error } =
       SLStatic.evaluateUfunc(funcName, body, prev, args);
@@ -349,8 +349,8 @@ const SLPopup = {
 
   loadFunctionHelpText() {
     const funcName = document.getElementById("recurFuncSelect").value;
-    if (this.ufuncs[funcName]) {
-      const helpTxt = this.ufuncs[funcName].help;
+    if (SLPopup.ufuncs[funcName]) {
+      const helpTxt = SLPopup.ufuncs[funcName].help;
       const funcHelpDiv = document.getElementById('funcHelpDiv');
       funcHelpDiv.textContent = helpTxt;
     } else {
@@ -401,7 +401,7 @@ const SLPopup = {
     const dom = SLPopup.objectifyDOMElements();
 
     const recurFuncSelect = dom['recurFuncSelect'];
-    [...Object.keys(this.ufuncs)].sort().forEach(funcName => {
+    [...Object.keys(SLPopup.ufuncs)].sort().forEach(funcName => {
       if (funcName !== "ReadMeFirst" && funcName !== "newFunctionName") {
         const newOpt = document.createElement('option');
         newOpt.id = `ufunc-${funcName}`;
@@ -554,12 +554,12 @@ const SLPopup = {
   },
 
   async init() {
-    this.tabId = await browser.tabs.query({
+    SLPopup.tabId = await browser.tabs.query({
       active:true, currentWindow:true
     }).then(tabs => tabs[0].id);
 
     const { ufuncs } = await browser.storage.local.get({ ufuncs: {} });
-    this.ufuncs = ufuncs;
+    SLPopup.ufuncs = ufuncs;
 
     SLPopup.attachListeners();
 

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -44,6 +44,16 @@ const SLPopup = {
     setTimeout((() => window.close()), 150);
   },
 
+  doPlaceInOutbox() {
+    const message = {
+      tabId: SLPopup.tabId,
+      action: "doPlaceInOutbox"
+    };
+    SLStatic.debug(message);
+    browser.runtime.sendMessage(message).catch(SLStatic.error);
+    setTimeout((() => window.close()), 150);
+  },
+
   domElementsAsArray() {
     return [...document.querySelectorAll("*")];
   },
@@ -549,6 +559,7 @@ const SLPopup = {
     });
 
     dom["sendNow"].addEventListener("click", SLPopup.doSendNow);
+    dom["placeInOutbox"].addEventListener("click", SLPopup.doPlaceInOutbox);
 
     setTimeout(() => document.getElementById("send-datetime").select(), 50);
   },

--- a/utils/static.js
+++ b/utils/static.js
@@ -184,7 +184,7 @@ var SLStatic = {
       const FUNC = Function.apply(null, ["specname", "prev", "args", funcStr]);
       response = FUNC(name, prev, args);
     } catch (ex) {
-      SLStatic.warn(ex);
+      SLStatic.debug(`User function ${name} (prev: ${prev}, args: ${args}) returned error.`,ex);
       return { error: ex.message };
     }
 


### PR DESCRIPTION
Lots of minor tweaks to make the scheduler popup more helpful.

* Put in outbox is now an option, alongside "send now"
* Finish fixing #119 by ensuring that saved schedule values are populated correctly (they were being overwritten during the initialization step.)
* Make parsing and formatting times aware of the actual time offset of the main loop (i.e. Send Later does not necessarily execute on the minute).
* Dynamically update the schedule button, so that the relative time fields stays accurate even if the popup is left open for an extended period of time.