### PR TITLE
Adjust inputs for schedule restrictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ release: release/send_later-${version}-tb.xpi
 lint:
 	addons-linter .
 
-unit_test: $(shell find $(shell cat dev/include-manifest) 2>/dev/null)
+unit_test: $(shell find $(shell cat dev/include-manifest) | grep -v '_locales' 2>/dev/null)
 	@node test/run_tests.js 2>&1 \
 		| sed -e '/^+ TEST'/s//"`printf '\033[32m+ TEST\033[0m'`"'/' \
 		| sed -e '/^- TEST'/s//"`printf '\033[31m- TEST\033[0m'`"'/' \

--- a/utils/static.js
+++ b/utils/static.js
@@ -817,9 +817,27 @@ var SLStatic = {
   //    than the scheduled day, or if there is none, then the smallest day in
   //    the restriction overall.
   adjustDateForRestrictions(sendAt, start_time, end_time, days) {
+    convertTime = (t) => {
+      if (!t) {
+        return null;
+      } else if (typeof t === "string") {
+        return SLStatic.parseDateTime(null, t) || new Date(t);
+      } else if (typeof t === "number") {
+        if (t < 2401) {
+          return SLStatic.parseDateTime(null, `${t}`);
+        } else {
+          return new Date(t);
+        }
+      } else if (t.getTime) {
+        return new Date(t.getTime());
+      } else {
+        throw new Error(`Send Later error: unable to parse time format ${t}`);
+      }
+    }
+
     let dt = new Date(sendAt.getTime());
-    start_time = start_time && SLStatic.parseDateTime(null,start_time);
-    end_time = end_time && SLStatic.parseDateTime(null,end_time);
+    start_time = convertTime(start_time);
+    end_time = convertTime(end_time);
 
     if (start_time && SLStatic.compareTimes(dt, '<', start_time)) {
       // If there is a time restriction and the scheduled time is before it,


### PR DESCRIPTION
The popup dialog did not initially apply the date/time restrictions to the first occurrence of a message schedule, only subsequent messages would be affected by those restrictions. This patch fixes that.