### PR TITLE
Enable opt-out of resend message warnings

### DIFF
--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -424,6 +424,21 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           return Services.prompt.alert(window, (title || ""), (text || ""));
         },
 
+        async confirmCheck(title, message, checkMessage, state) {
+          function doConfirmCheck(resolve, reject) {
+            try {
+              let checkbox = { value: state };
+              let okToProceed = Services.prompt.confirmCheck(
+                null, title, message, checkMessage, checkbox
+              );
+              resolve(okToProceed && checkbox.value);
+            } catch (err) {
+              reject(`An error occurred in SL3U.doConfirmCheck: ${err}`);
+            }
+          }
+          return new Promise(doConfirmCheck.bind(this));
+        },
+
         async setLegacyPref(name, dtype, value) {
           const prefName = `extensions.sendlater3.${name}`;
 

--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -33,6 +33,29 @@
         ]
       },
       {
+        "name":"confirmCheck",
+        "type":"function",
+        "async":true,
+        "parameters":[
+          {
+            "name":"title",
+            "type":"string"
+          },
+          {
+            "name":"message",
+            "type":"string"
+          },
+          {
+            "name": "checkMessage",
+            "type": "string"
+          },
+          {
+            "name": "state",
+            "type": "boolean"
+          }
+        ]
+      },
+      {
         "name": "generateMsgId",
         "type": "function",
         "async": true,


### PR DESCRIPTION
Workaround for #126 -- There is no webextension mechanism for telling whether a message has been 'marked as deleted', so send later will complain loudly whenever it encounters one of its own messages. This patch gives users an opt-out to silence those messages.