### PR TITLE
Bump minor version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 
   "description": "__MSG_extensionDescription__",
 
-  "version": "8.3.0",
+  "version": "8.4.0",
 
   "homepage_url": "https://github.com/Extended-Thunder/send-later/",
 


### PR DESCRIPTION
Keeping with release schedule, 8.3.x is now on its own branch, and the main branch should be bumped to 8.4