### PR TITLE
Improve option dialog, and do message operations earlier in loop

### DIFF
--- a/ui/options.html
+++ b/ui/options.html
@@ -66,7 +66,7 @@
         <span class="option-label localized __MSG_blockLateMessagesPrefLabel1__">
           Don't deliver messages more than</span>
         <input type="number" min=1 style="width:6em;" id="lateGracePeriod" class="preference"/>
-        <span class="option-label localized __MSG_blockLateMessagesPrefLabel2__">
+        <span class="option-label localized __MSG_blockLateMessagesPrefLabel2__" id="gracePeriodUnitLabel">
           minutes late</span>
       </label>
 


### PR DESCRIPTION
This performs the `browser.messages.getRaw` operation inside the main forAllDrafts function, slightly reducing the level of asynchronousness.

It also adds a dropdown to the options page so that the late message grace period can be set in terms of hours or days rather than just minutes.