### PR TITLE
Improve message fetching by only retrieving data as absolutely necessary

### DIFF
--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -166,6 +166,14 @@
           {
             "name": "path",
             "type": "string"
+          },
+          {
+            "name": "onlyDueForSend",
+            "type": "boolean"
+          },
+          {
+            "name": "onlyHeaders",
+            "type": "boolean"
           }
         ]
       },


### PR DESCRIPTION
The workaround for #16 that's included in v8.4.5 loads lots of messages in the background, which could get unwieldy for cases with lots of messages, or some very large messages.

This patch skips loading data that isn't strictly necessary at any particular time. In particular, when looking for messages that are due for sending, check the headers for 'x-send-later-at' in the past before bothering to fetch the full message at all. Similarly, in cases where all we need is header data, then don't bother fetching any full messages at all.