### PR TITLE
Improve log level handling in experiment context.

### DIFF
--- a/background.js
+++ b/background.js
@@ -159,7 +159,7 @@ const SendLater = {
       if (success) {
         browser.tabs.remove(tabId);
       } else {
-        console.error("Something went wrong while scheduling this message.");
+        SLStatic.error("Something went wrong while scheduling this message.");
       }
     },
 
@@ -931,7 +931,6 @@ browser.runtime.onMessage.addListener(async (message) => {
         return (SendLater.composeState[message.tabId] === "scheduling") ||
                 (await SendLater.preSendCheck.call(SendLater));
       })().then(dosend => {
-        console.log(dosend);
         if (dosend) {
           const options = { sendAt: message.sendAt,
                             recurSpec: message.recurSpec,
@@ -947,7 +946,7 @@ browser.runtime.onMessage.addListener(async (message) => {
     }
     case "closingComposePopup": {
       delete SendLater.composeState[message.tabId];
-      console.log(`Removed tab ${message.tabId} from composeState map.`);
+      SLStatic.debug(`Removed tab ${message.tabId} from composeState map.`);
       break;
     }
     case "getScheduleText": {
@@ -1012,6 +1011,8 @@ browser.messages.onNewMailReceived.addListener((folder, messagelist) => {
   if (["sent", "trash", "archives", "junk", "outbox"].includes(folder.type)) {
     SLStatic.debug(`Skipping onNewMailReceived for folder type ${folder.type}`);
     return;
+  } else {
+    SLStatic.debug(`Messages received in folder ${folder.path}`);
   }
 
   // We can't do this processing right away, because the message might not be

--- a/experiments/headerView.js
+++ b/experiments/headerView.js
@@ -253,11 +253,17 @@ SendLaterHeaderView = {
           if (schedule !== null) {
             try {
               let hdrText = SLStatic.formatScheduleForUIColumn(schedule);
-              document.getElementById("sendlater-expanded-Box").headerValue = hdrText;
-              isHidden = false;
-              SLStatic.debug(
-                "headerView.js: onBeforeShowHeaderPane: showing header"
-              );
+              const headerBoxElement = document.getElementById("sendlater-expanded-Box");
+              if (headerBoxElement) {
+                headerBoxElement.headerValue = hdrText;
+                isHidden = false;
+                SLStatic.debug(
+                  "headerView.js: onBeforeShowHeaderPane: showing header"
+                );
+              } else {
+                SLStatic.warn(`Unable to find sendlater-expanded-box element`);
+              }
+
             } catch (e) {
               SLStatic.debug(e);
               if (SendLaterHeaderView.onBeforeShowHeaderPaneWarning) {

--- a/utils/static.js
+++ b/utils/static.js
@@ -27,7 +27,7 @@ var SLStatic = {
     try {
       const { preferences } = await browser.storage.local.get({"preferences": {}});
       this.logConsoleLevel = (preferences.logConsoleLevel || "all").toLowerCase();
-      console.log(`Received logConsoleLevel: ${logConsoleLevel}`);
+      console.log(`Received logConsoleLevel: ${this.logConsoleLevel}`);
     } catch {}
   },
 


### PR DESCRIPTION
The experiment script didn't have a real log level concept before -- just relied on the different `console.` methods. This patch adds the same sort of preference-based filtering to the experiment script as exists in the rest of the addon, and adjusts log levels to be more appropriate to their actual importance.