### PR TITLE
Enable more access keys, including arbitrary user-defined shortcuts

### DIFF
--- a/ui/localize.js
+++ b/ui/localize.js
@@ -1,26 +1,24 @@
-const localizer = {
-  async translateDocument() {
-    const elements = document.querySelectorAll(".localized");
-    elements.forEach(async e => {
-      try {
-        const key = e.className.match(/__MSG_(.+)__/)[1];
-        const mockArgs = [];
-        let msg;
-        do {
-          msg = browser.i18n.getMessage(key,mockArgs);
-          mockArgs.push("");
-        } while(msg.indexOf(/\$\d/) !== -1);
-        if (e.tagName === "INPUT" || e.tagName === "TEXTAREA") {
-          e.value = msg;
-        } else {
-          e.textContent = msg;
-        }
-      } catch (err) {
-        SLStatic.error("Localization error", err, e);
+function translateDocument() {
+  const elements = document.querySelectorAll(".localized");
+  elements.forEach(async e => {
+    try {
+      const key = e.className.match(/__MSG_(.+)__/)[1];
+      const mockArgs = [];
+      let msg;
+      do {
+        msg = browser.i18n.getMessage(key,mockArgs);
+        mockArgs.push("");
+      } while(msg.indexOf(/\$\d/) !== -1);
+      if (e.tagName === "INPUT" || e.tagName === "TEXTAREA") {
+        e.value = msg;
+      } else {
+        e.textContent = msg;
       }
-    });
-  }
-};
+    } catch (err) {
+      SLStatic.error("Localization error", err, e);
+    }
+  });
+}
 
 if (typeof browser === "undefined" || typeof browserMocking === "boolean") {
   // For testing purposes, because the browser mock script needs to
@@ -29,12 +27,12 @@ if (typeof browser === "undefined" || typeof browserMocking === "boolean") {
     if (browser.i18n.getMessage("advancedOptionsTitle") === "advancedOptionsTitle") {
       setTimeout(waitAndTranslate, 10);
     } else {
-      localizer.translateDocument();
+      translateDocument();
     }
   }
   window.addEventListener("load", waitAndTranslate, false);
   // window.addEventListener("load", () =>
-  //   setTimeout(localizer.translateDocument,150), false);
+  //   setTimeout(translateDocument,150), false);
 } else {
-  window.addEventListener("load", localizer.translateDocument, false);
+  window.addEventListener("load", translateDocument, false);
 }

--- a/ui/options.html
+++ b/ui/options.html
@@ -325,8 +325,8 @@
     <script type="text/javascript" src="/utils/sugar-custom.js"></script>
     <script type="text/javascript" src="/utils/varNameValidator.js"></script>
     <script type="text/javascript" src="/utils/static.js"></script>
-    <script type="text/javascript" src="/ui/options.js"></script>
     <script type="text/javascript" src="/ui/localize.js"></script>
+    <script type="text/javascript" src="/ui/options.js"></script>
   </body>
 
 </html>

--- a/ui/popup.html
+++ b/ui/popup.html
@@ -206,30 +206,37 @@
       <table style="width:100%">
         <tr>
           <td>
-          <input type="button" value="in 15 minutes" id="quick-opt-1"
-            style="width:100%;" class="delayButton" />
+            <button id="quick-opt-1" style="width:100%;" class="delayButton">
+              in 15 minutes
+            </button>
           </td>
           <td>
-          <input type="button" value="in 30 minutes" id="quick-opt-2"
-            style="margin:0 2.5%;width:95%;" class="delayButton" />
+            <button id="quick-opt-2" style="width:100%;" class="delayButton">
+              in 30 minutes
+            </button>
           </td>
           <td>
-          <input type="button" value="in 2 hours" id="quick-opt-3"
-            style="width:100%;" class="delayButton" />
+            <button id="quick-opt-3" style="width:100%;" class="delayButton">
+              in 2 hours
+            </button>
           </td>
         </tr>
       </table>
       <table style="width:100%;float:center;">
         <tr>
           <td>
-          <input type="button" value="Send Now" id="sendNow"
-            class="localized __MSG_sendNowLabel__"
-            style="margin:0 2.5%;width:95%;" class="delayButton"/>
+            <button id="sendNow"
+              class="localized __MSG_sendNowLabel__"
+              style="margin:0 2.5%;width:95%;" class="delayButton">
+              Send Now
+            </button>
           </td>
           <td>
-            <input type="button" value="Put in Outbox" id="placeInOutbox"
-              class="localized __MSG_sendlater.prompt.sendlater.label__"
-              style="margin:0 2.5%;width:95%;" class="delayButton"/>
+              <button id="placeInOutbox"
+                class="localized __MSG_sendlater.prompt.sendlater.label__"
+                style="margin:0 2.5%;width:95%;" class="delayButton">
+                Put in Outbox
+              </button>
             </td>
         </tr>
       </table>
@@ -237,8 +244,8 @@
 
     <script type="text/javascript" src="/utils/sugar-custom.js"></script>
     <script type="text/javascript" src="/utils/static.js"></script>
-    <script type="text/javascript" src="/ui/popup.js"></script>
     <script type="text/javascript" src="/ui/localize.js"></script>
+    <script type="text/javascript" src="/ui/popup.js"></script>
   </body>
 
 </html>

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -613,7 +613,18 @@ const SLPopup = {
         const funcArgs = preferences[`quickOptions${i}Args`];
 
         const quickBtn = dom[`quick-opt-${i}`];
-        quickBtn.value = preferences[`quickOptions${i}Label`];
+        const quickBtnLabel = preferences[`quickOptions${i}Label`];
+        const accelIdx = quickBtnLabel.indexOf("&");
+        if (accelIdx === -1) {
+          quickBtn.textContent = quickBtnLabel;
+        } else {
+          quickBtn.accessKey = quickBtnLabel[accelIdx+1];
+          const contents = SLStatic.underlineAccessKey(quickBtnLabel);
+          quickBtn.textContent = "";
+          for (let span of contents) {
+            quickBtn.appendChild(span);
+          }
+        }
         quickBtn.addEventListener("click", () => {
           const schedule = SLPopup.evaluateUfunc(funcName, null, funcArgs);
           SLPopup.doSendWithSchedule(schedule);
@@ -641,6 +652,29 @@ const SLPopup = {
 
     dom["sendNow"].addEventListener("click", SLPopup.doSendNow);
     dom["placeInOutbox"].addEventListener("click", SLPopup.doPlaceInOutbox);
+
+    (() => {
+      const label = browser.i18n.getMessage("sendNowLabel");
+      const accessKey = browser.i18n.getMessage("sendlater.prompt.sendnow.accesskey");
+      const contents = SLStatic.underlineAccessKey(label, accessKey);
+
+      dom["sendNow"].accessKey = accessKey;
+      dom["sendNow"].textContent = "";
+      for (let span of contents) {
+        dom["sendNow"].appendChild(span);
+      }
+    })();
+    (() => {
+      const label = browser.i18n.getMessage("sendlater.prompt.sendlater.label");
+      const accessKey = browser.i18n.getMessage("sendlater.prompt.sendlater.accesskey");
+      const contents = SLStatic.underlineAccessKey(label, accessKey);
+
+      dom["placeInOutbox"].accessKey = accessKey;
+      dom["placeInOutbox"].textContent = "";
+      for (let span of contents) {
+        dom["placeInOutbox"].appendChild(span);
+      }
+    })();
 
     setTimeout(() => document.getElementById("send-datetime").select(), 50);
   },

--- a/utils/static.js
+++ b/utils/static.js
@@ -208,6 +208,31 @@ var SLStatic = {
     }
   },
 
+  // Splits a single label string into spans, where the first occurrence
+  // of the access key is in its own element, with an underline.
+  underlineAccessKey(label, modifier) {
+    let idx = label.indexOf(modifier||"&");
+    if (idx === -1 && modifier) {
+      modifier = modifier.toLowerCase();
+      idx = label.toLowerCase().indexOf(modifier);
+    }
+
+    if (idx === -1) {
+      const spanner = document.createElement("SPAN");
+      spanner.textContent = label;
+      return [spanner];
+    } else {
+      const span1 = document.createElement("SPAN");
+      span1.textContent = label.substr(0,idx);
+      const span2 = document.createElement("SPAN");
+      span2.style.textDecoration = "underline";
+      span2.textContent = modifier ? label[idx] : label[++idx];
+      const span3 = document.createElement("SPAN");
+      span3.textContent = label.substr(idx+1);
+      return [span1, span2, span3];
+    }
+  },
+
   evaluateUfunc(name, body, prev, args) {
     const funcStr =
       `let next, nextspec, nextargs;\n` +


### PR DESCRIPTION
Binds Send Now and Place in Outbox to the correct default access keys, and allows users to select arbitrary access keys for their shortcuts by adding an & to the label. Fixes #149 