### PR TITLE
Fixup for folder enumeration fallback

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 
   "description": "__MSG_extensionDescription__",
 
-  "version": "8.5.3",
+  "version": "8.5.4",
 
   "homepage_url": "https://github.com/Extended-Thunder/send-later/",
 


### PR DESCRIPTION
Misplaced brackets were skipping one of the crucial fallback cases for locating the drafts folder message enumerator.