### PR TITLE
Improve handling of day/time restrictions

### DIFF
--- a/background.js
+++ b/background.js
@@ -234,8 +234,8 @@ const SendLater = {
       if (preferences.enforceTimeRestrictions) {
         // Respect "send between" preference
         if (recur.between) {
-          if (SLStatic.compareTimes(Date.now(), '<=', recur.between.start) ||
-              SLStatic.compareTimes(Date.now(), '>=', recur.between.end)) {
+          if (SLStatic.compareTimes(Date.now(), '<', recur.between.start) ||
+              SLStatic.compareTimes(Date.now(), '>', recur.between.end)) {
             SLStatic.debug(
               `Message ${msgHdr.id} ${originalMsgId} outside of sendable time range.`,
               recur.between);
@@ -249,6 +249,7 @@ const SendLater = {
           if (!recur.days.includes(today)) {
             const wkday = new Intl.DateTimeFormat('default', {weekday:'long'});
             SLStatic.debug(`Message ${msgHdr.id} not scheduled to send on ${wkday.format(new Date())}`,recur.days);
+            return;
           }
         }
       }


### PR DESCRIPTION
Several improvements to the scheduler UI for edge cases when switching around between various schedule options (e.g. switch to "monthly", then back to "once" then to "function", the proper set of elements was not always displayed/hidden). Also, when applying saved defaults, the schedule button was not being auto-filled right away. Those should work more smoothly now.

More important bug: the send-time weekday restrictions were not being enforced correctly (at all, actually). There was a missing 'return', so the restriction was only printing a warning and then continuing on as usual. That is fixed.

Also, the way the restriction had been implemented (even if the missing 'return' were replaced) would have just waited until a valid weekday, and then sent at its first opportunity. So for example, a message which is scheduled to only send on M/W/F at noon, which is prevented from sending until Saturday, would have been blocked until Monday, but would have been sent at the first check on Monday (around midnight). That is now fixed, so the message will get rescheduled for Monday at noon.