### PR TITLE
Reuse sendUnsentMessages code from mailWindowOverlay.

### DIFF
--- a/ui/popup.js
+++ b/ui/popup.js
@@ -407,11 +407,12 @@ const SLPopup = {
   saveDefaults() {
     const defaults = SLPopup.serializeInputs();
     SLStatic.debug("Saving default values", defaults);
+    const saveDefaultsElement = document.getElementById("save-defaults");
     browser.storage.local.set({ defaults }).then(() => {
-      SLPopup.showCheckMark(dom["save-defaults"], "green");
+      SLPopup.showCheckMark(saveDefaultsElement, "green");
     }).catch((err) => {
       SLStatic.error(err);
-      SLPopup.showCheckMark(dom["save-defaults"], "red");
+      SLPopup.showCheckMark(saveDefaultsElement, "red");
     });
   },
 


### PR DESCRIPTION
Literally duplicate the 'sendUnsentMessages' function from mailWindowOverlay.js in case it fixes the apparent bug with 32-bit portable thunderbird. I'm not going to merge this yet because I haven't actually tested it.