### PR TITLE
Allow Send Later to auto-update from ATN

### DIFF
--- a/background.js
+++ b/background.js
@@ -1323,18 +1323,18 @@ browser.commands.onCommand.addListener((cmd) => {
   }
 });
 
-browser.runtime.onUpdateAvailable.addListener((details) => {
-  const extensionName = browser.i18n.getMessage("extensionName");
-  const thisVersion = browser.runtime.getManifest().version;
-  const nextVersion = details.version||"";
-
-  browser.notifications.create(null, {
-    "type": "basic",
-    "title": `${extensionName} ${thisVersion}`,
-    "message": `${extensionName} ${nextVersion} is available and ` +
-               `will be upgraded next time you restart Thunderbird.`
-  });
-});
+// browser.runtime.onUpdateAvailable.addListener((details) => {
+//   const extensionName = browser.i18n.getMessage("extensionName");
+//   const thisVersion = browser.runtime.getManifest().version;
+//   const nextVersion = details.version||"";
+//
+//   browser.notifications.create(null, {
+//     "type": "basic",
+//     "title": `${extensionName} ${thisVersion}`,
+//     "message": `${extensionName} ${nextVersion} is available and ` +
+//                `will be upgraded next time you restart Thunderbird.`
+//   });
+// });
 
 async function getDraftFoldersHelper(folder) {
   // Recursive helper function to look through an account for draft folders


### PR DESCRIPTION
I suspect this is why Send Later is being disabled for some users when new updates become available. That's not what the documentation claims this function should do, but it's my prime suspect. I'm reasonably confident in Send Later's ability to clean up after itself, so auto-update should be okay anyways.