### PR TITLE
Revert to custom setHeader method

### DIFF
--- a/background.js
+++ b/background.js
@@ -138,18 +138,25 @@ const SendLater = {
         );
       }
 
-      // Merge the new custom headers into the original headers
-      // Note: this shouldn't be necessary, but it appears that
-      // `setComposeDetails` does not preserve existing headers.
-      let composeDetails = await messenger.compose.getComposeDetails(tabId);
-      for (let hdr of composeDetails.customHeaders) {
-        if (!hdr.name.toLowerCase().startsWith("x-send-later")) {
-          customHeaders.push(hdr);
-        }
+      // // // Merge the new custom headers into the original headers
+      // // // Note: this shouldn't be necessary, but it appears that
+      // // // `setComposeDetails` does not preserve existing headers.
+      // // let composeDetails = await messenger.compose.getComposeDetails(tabId);
+      // // for (let hdr of composeDetails.customHeaders) {
+      // //   if (!hdr.name.toLowerCase().startsWith("x-send-later")) {
+      // //     customHeaders.push(hdr);
+      // //   }
+      // // }
+      // // composeDetails.customHeaders = customHeaders;
+      // // SLStatic.info("Saving message with details:", composeDetails);
+      // // await messenger.compose.setComposeDetails(tabId, composeDetails);
+      //
+      // The setComposeDetails method seems to drop all unsupported headers
+      // (which is most of the headers). This breaks things like replies
+      // which need to retain the "in-reply-to" header (for example).
+      for (let hdr of customHeaders) {
+        await messenger.SL3U.setHeader(tabId, hdr.name, hdr.value);
       }
-      composeDetails.customHeaders = customHeaders;
-      SLStatic.info("Saving message with details:", composeDetails);
-      await messenger.compose.setComposeDetails(tabId, composeDetails);
 
       // Save the message as a draft
       let saveProperties = await messenger.compose.saveMessage(

--- a/experiments/sl3u.js
+++ b/experiments/sl3u.js
@@ -655,6 +655,12 @@ var SL3U = class extends ExtensionCommon.ExtensionAPI {
           return true;
         },
 
+        async setHeader(tabId, name, value) {
+          let tab = context.extension.tabManager.get(tabId);
+          let window = tab.nativeTab;
+          window.gMsgCompose.compFields.setHeader(name, value);
+        },
+
         async setCustomDBHeaders(requestedHdrs) {
           // mailnews.customDBHeaders
           let originals = [];

--- a/experiments/sl3u.json
+++ b/experiments/sl3u.json
@@ -139,6 +139,29 @@
         ]
       },
       {
+        "name":"setHeader",
+        "type":"function",
+        "async":true,
+        "description":"Add a custom header to a compose message",
+        "parameters": [
+          {
+            "name":"tabId",
+            "type":"integer",
+            "description":"Compose window to modify"
+          },
+          {
+            "name":"name",
+            "type":"string",
+            "description":"Name of the header to set"
+          },
+          {
+            "name":"value",
+            "type":"string",
+            "description":"Value of custom header"
+          }
+        ]
+      },
+      {
         "name": "setCustomDBHeaders",
         "type": "function",
         "async": true,

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 
   "description": "__MSG_extensionDescription__",
 
-  "version": "9.2.1",
+  "version": "9.2.2",
 
   "homepage_url": "https://github.com/Extended-Thunder/send-later/",
 

--- a/utils/static.js
+++ b/utils/static.js
@@ -1558,7 +1558,8 @@ if (typeof browser === "undefined" && typeof require !== "undefined") {
       }
     },
     SL3U: {
-      getLegacyPref(name, dtype, def){return null;}
+      async getLegacyPref(name, dtype, def){return null;},
+      async setHeader(tabId, name, value){return null},
     }
   }
 


### PR DESCRIPTION
`compose.setComposeDetails` was stripping important headers. Revert to old experiment method.