### PR TITLE
Fix schedule caching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 
   "description": "__MSG_extensionDescription__",
 
-  "version": "9.2.5",
+  "version": "9.2.6",
 
   "homepage_url": "https://github.com/Extended-Thunder/send-later/",
 

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -419,14 +419,17 @@ const SLPopup = {
     return inputs;
   },
 
-  async cacheSchedule() {
-    SLStatic.debug(`Caching current input values`);
-    const { scheduleCache } = await browser.storage.local.get({ scheduleCache: {} });
-    const cwin = await browser.windows.getCurrent();
-    scheduleCache[cwin.id] = SLPopup.serializeInputs();
-    browser.storage.local.set({ scheduleCache }).catch((err) => {
-      SLStatic.error(err);
-    });
+  cacheSchedule() {
+    SLStatic.debug("Caching current input values");
+    browser.storage.local.get({ scheduleCache: {} }).then(
+      ({ scheduleCache }) => {
+        browser.windows.getCurrent().then(
+          (cwin) => {
+            scheduleCache[cwin.id] = SLPopup.serializeInputs();
+            browser.storage.local.set({ scheduleCache });
+          });
+      }
+    ).catch(SLStatic.error);
   },
 
   saveDefaults() {

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -4,6 +4,10 @@
 var _popupCallbacks = new Map();
 
 var SLTools = {
+  // Set of message ID's which are scheduled
+  scheduledMsgCache: new Set(),
+  // Set of message ID's which are not scheduled
+  unscheduledMsgCache: new Set(),
 
   // Convenience function for getting preferences.
   async getPrefs() {
@@ -180,9 +184,6 @@ var SLTools = {
     });
   },
 
-  scheduledMsgCache: new Set(),
-  unscheduledMsgCache: new Set(),
-
   // Count draft messages containing the correct `x-send-later-uuid` header.
   async countActiveScheduledMessages() {
     const preferences = await SLTools.getPrefs();
@@ -209,3 +210,7 @@ var SLTools = {
     return isScheduled.filter(x => x).length;
   },
 };
+
+messenger.tabs.onRemoved.addListener(tabId => {
+  SLTools.handlePopupCallback(tabId, { ok: false, check: null });
+});


### PR DESCRIPTION
Work-around for case where a message is saved multiple times during composition. Need to ensure that once it actually does get scheduled it is not part of the unscheduledMsgCache. Otherwise it will get ignored when checking for scheduled messages.