### PR TITLE
Improve handling of errors during extension initialization.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 
   "description": "__MSG_extensionDescription__",
 
-  "version": "9.2.8",
+  "version": "9.2.9",
 
   "homepage_url": "https://github.com/Extended-Thunder/send-later/",
 
@@ -19,7 +19,7 @@
     "gecko": {
       "id": "sendlater3@kamens.us",
       "strict_min_version": "102.0",
-      "strict_max_version": "110.0"
+      "strict_max_version": "*"
     }
   },
 

--- a/utils/static.js
+++ b/utils/static.js
@@ -68,6 +68,16 @@ var SLStatic = {
     this.trace = logThreshold("trace") ? console.trace : ()=>{};
   },
 
+  // Run a function and report any errors to the console, but don't let the error
+  // propagate to the caller.
+  nofail(func, ...args) {
+    if (func[Symbol.toStringTag] === "AsyncFunction") {
+      func(...args).catch(console.error);
+    } else {
+      try { func(...args) } catch (e) { console.error(e) }
+    }
+  },
+
   get customizeDateTime() {
     if (this._customizeDateTime === null) {
       this.cachePrefs().catch(console.error);


### PR DESCRIPTION
The most common reason for bug reports like "send later just doesn't work" seems to be cases where something threw an exception during the initialization step, so the main loop never actually starts.

This patch adds some try/catch logic to some of the noncritical initialization steps, to maximize likelihood that the core functionality continues working as expected.

It also improves handling of cases where intiialization still fails, by thoroughly disabling the UI elements and background listeners. That should help prevent the situation where the extension "appears" active, even though it is not actually executing its main loop.