### PR TITLE
Make sure to await  all async calls

### DIFF
--- a/background.js
+++ b/background.js
@@ -1022,9 +1022,13 @@ const SendLater = {
         }
         case "getPreferences": {
           // Return Promise for the allowed preferences.
-          return SLTools.getPrefs()
-            .then(preferences => preferences.filter(prop => SLStatic.prefInputIds.includes(prop)))
-            .catch(ex => SLStatic.error(ex));
+          return SLTools.getPrefs().then((prefs) => {
+            prefs = Object.entries(prefs);
+            prefs = prefs.filter(([key, value]) =>
+              SLStatic.prefInputIds.includes(key));
+            prefs = Object.fromEntries(prefs);
+            return prefs;
+          }).catch(ex => SLStatic.error(ex));
         }
         case "setPreferences": {
           const setAndReturnPrefs = async (old_prefs, new_prefs) => {

--- a/background.js
+++ b/background.js
@@ -871,7 +871,7 @@ const SendLater = {
         }
       });
     },
-      
+
     async tabUpdatedListener(tabId, changeInfo, tab) {
       SLStatic.debug(`SLTABS: tabUpdatedListener tab.status=${tab.status} tab.mailTab=${tab.mailTab}`);
       if (tab.status != "complete" || ! tab.mailTab) return;
@@ -951,7 +951,7 @@ const SendLater = {
           // console.debug({originalMsg, newMsg});
 
           await SendLater.updateStatusIndicator();
-    
+
           // Set popup scheduler defaults based on original message
           scheduleCache[window.id] =
           SLStatic.parseHeadersForPopupUICache(originalMsgPart.headers);
@@ -1069,7 +1069,7 @@ const SendLater = {
                 throw new Error (`Property ${prop} is not a valid Send Later preference.`);
               }
               if (
-                prop in old_prefs && 
+                prop in old_prefs &&
                 typeof(old_prefs[prop]) != "undefined" &&
                 typeof(new_prefs[prop]) != "undefined" &&
                 typeof(old_prefs[prop]) != typeof(new_prefs[prop])
@@ -1420,7 +1420,7 @@ async function mainLoop() {
         await SendLater.updateStatusIndicator(nActive);
         await SendLater.setQuitNotificationsEnabled(
           preferences.askQuit, nActive);
-        
+
         SendLater.previousLoop = new Date();
         SendLater.loopTimeout = setTimeout(mainLoop, 60000);
         SLStatic.debug(`Next main loop iteration in 1 minute.`);

--- a/background.js
+++ b/background.js
@@ -951,7 +951,7 @@ const SendLater = {
         case "key_altShiftEnter": {
           if (SendLater.prefCache.altBinding) {
             SLStatic.info("Opening popup");
-            messenger.composeAction.openPopup();
+            await messenger.composeAction.openPopup();
           } else {
             SLStatic.info("Ignoring Alt+Shift+Enter on account of user preferences");
           }
@@ -970,14 +970,14 @@ const SendLater = {
               }
             } else {
               SLStatic.info("Opening popup");
-              messenger.composeAction.openPopup();
+              await messenger.composeAction.openPopup();
             }
             break;
           }
         case "cmd_sendLater":
           { // User clicked the "Send Later" menu item, which should always
             // open the Send Later popup.
-            messenger.composeAction.openPopup();
+            await messenger.composeAction.openPopup();
             break;
           }
         case "cmd_sendNow":
@@ -986,7 +986,7 @@ const SendLater = {
           {
             if (SendLater.prefCache.sendDoesSL) {
               SLStatic.debug("Opening scheduler dialog.");
-              messenger.composeAction.openPopup();
+              await messenger.composeAction.openPopup();
             } else if (SendLater.prefCache.sendDoesDelay) {
               // Schedule with delay.
               const sendDelay = SendLater.prefCache.sendDelay;
@@ -1304,9 +1304,9 @@ const SendLater = {
         SLStatic.info(`Executing accelerator Click+${mod}: ${funcName}(${funcArgs})`);
         SendLater.quickSendWithUfunc(funcName, funcArgs, tab.id);
       } else {
-        messenger.composeAction.setPopup({"popup": "ui/popup.html"});
-        messenger.composeAction.openPopup();
-        messenger.composeAction.setPopup({"popup": null});
+        await messenger.composeAction.setPopup({"popup": "ui/popup.html"});
+        await messenger.composeAction.openPopup();
+        await messenger.composeAction.setPopup({"popup": null});
       }
     },
 

--- a/background.js
+++ b/background.js
@@ -32,7 +32,7 @@ const SendLater = {
         });
         if (result.check === false) {
           preferences.showSendNowAlert = false;
-          messenger.storage.local.set({ preferences });
+          await messenger.storage.local.set({ preferences });
         }
         if (!result.ok) {
           SLStatic.debug(`User canceled send now.`);
@@ -56,7 +56,7 @@ const SendLater = {
         });
         if (result.check === false) {
           preferences.showOutboxAlert = false;
-          messenger.storage.local.set({ preferences });
+          await messenger.storage.local.set({ preferences });
         }
         if (!result.ok) {
           SLStatic.debug(`User canceled send later.`);
@@ -420,9 +420,8 @@ const SendLater = {
 
       if (success) {
         lock[msgLockId] = true;
-        await messenger.storage.local.set({ lock }).then(() => {
-          SLStatic.debug(`Locked message <${msgLockId}> from re-sending.`);
-        });
+        await messenger.storage.local.set({ lock });
+        SLStatic.debug(`Locked message <${msgLockId}> from re-sending.`);
         if (preferences.throttleDelay) {
           SLStatic.debug(`Throttling send rate: ${preferences.throttleDelay/1000}s`);
           await new Promise(resolve =>
@@ -928,7 +927,7 @@ const SendLater = {
             `Schedule cache item added for window ${window.id}:`,
             scheduleCache[window.id]
           );
-          messenger.storage.local.set({ scheduleCache });
+          await messenger.storage.local.set({ scheduleCache });
 
           // Alert the user about what just happened
           if (preferences.showEditAlert) {

--- a/background.js
+++ b/background.js
@@ -723,6 +723,7 @@ const SendLater = {
       messenger.runtime.onMessage.addListener(SendLater.onRuntimeMessageListenerasync);
       messenger.messageDisplay.onMessageDisplayed.addListener(SendLater.onMessageDisplayedListener);
       messenger.commands.onCommand.addListener(SendLater.onCommandListener);
+      messenger.composeAction.setPopup({"popup": "ui/popup.html"});
       messenger.composeAction.onClicked.addListener(SendLater.clickComposeListener);
       messenger.mailTabs.onDisplayedFolderChanged.addListener(SendLater.displayedFolderChangedListener);
       messenger.headerView.onHeaderRowUpdate.addListener(
@@ -1308,9 +1309,7 @@ const SendLater = {
         SLStatic.info(`Executing accelerator Click+${mod}: ${funcName}(${funcArgs})`);
         SendLater.quickSendWithUfunc(funcName, funcArgs, tab.id);
       } else {
-        await messenger.composeAction.setPopup({"popup": "ui/popup.html"});
         await messenger.composeAction.openPopup();
-        await messenger.composeAction.setPopup({"popup": null});
       }
     },
 
@@ -1328,7 +1327,6 @@ const SendLater = {
       });
       await SLStatic.nofail(messenger.browserAction.setBadgeText, {text: null});
       await SLStatic.nofail(messenger.composeAction.disable);
-      await SLStatic.nofail(messenger.composeAction.setPopup, {"popup": null});
       await SLStatic.nofail(messenger.messageDisplayAction.disable);
       await SLStatic.nofail(messenger.messageDisplayAction.setPopup, {"popup": null});
       await SLStatic.nofail(messenger.windows.onCreated.removeListener, SendLater.onWindowCreatedListener);

--- a/background.js
+++ b/background.js
@@ -398,7 +398,7 @@ const SendLater = {
               }).catch(SLStatic.error);;
               return;
             } else {
-              SLStatic.error("Unable to schedule next recuurrence.");
+              SLStatic.error("Unable to schedule next recurrence.");
               return;
             }
           }
@@ -1222,7 +1222,7 @@ const SendLater = {
       return response;
     },
 
-    // Listen for incoming messages, and check if they are in reponse to a scheduled
+    // Listen for incoming messages, and check if they are in response to a scheduled
     // message with a 'cancel-on-reply' header.
     async onNewMailReceivedListener(folder, messagelist) {
       if (["sent", "trash", "templates", "archives", "junk", "outbox"].includes(folder.type)) {
@@ -1236,9 +1236,7 @@ const SendLater = {
         SLStatic.debug("Got message", rcvdHdr, rcvdMsg);
         let inReplyTo = (rcvdMsg.headers["in-reply-to"]||[])[0];
         if (inReplyTo) {
-          // This does not stack handling of messages, but jumps back and forth
-          // and switches between them and handles them "in parallel".
-          SLTools.forAllDrafts(async (draftHdr) => {
+          await SLTools.forAllDrafts(async (draftHdr) => {
             if (!SLTools.unscheduledMsgCache.has(draftHdr.id)) {
               SLStatic.debug(
                 "Comparing", rcvdHdr, "to", draftHdr,
@@ -1373,6 +1371,8 @@ async function mainLoop() {
       messenger.browserAction.setTitle({title: `${extName} [${isActiveMessage}]`});
 
       let doSequential = preferences.throttleDelay > 0;
+      console.debug({doSequential, throttleDelay: preferences.throttleDelay});
+
       try {
         await SLTools.forAllDrafts(SendLater.possiblySendMessage, doSequential)
         let nActive = await SLTools.countActiveScheduledMessages();

--- a/background.js
+++ b/background.js
@@ -678,15 +678,15 @@ const SendLater = {
       if (nActive == undefined)
         nActive = await SLTools.countActiveScheduledMessages();
       if (nActive) {
-        messenger.browserAction.setTitle({title: (
+        await messenger.browserAction.setTitle({title: (
           `${extName} [${messenger.i18n.getMessage("PendingMessage", [nActive])}]`
         )});
-        messenger.browserAction.setBadgeText({text: String(nActive)});
+        await messenger.browserAction.setBadgeText({text: String(nActive)});
       } else {
-        messenger.browserAction.setTitle({title: (
+        await messenger.browserAction.setTitle({title: (
           `${extName} [${messenger.i18n.getMessage("IdleMessage")}]`
         )});
-        messenger.browserAction.setBadgeText({text: null});
+        await messenger.browserAction.setBadgeText({text: null});
       }
     },
 
@@ -820,7 +820,7 @@ const SendLater = {
 
         SendLater.setQuitNotificationsEnabled(preferences.askQuit);
 
-        messenger.browserAction.setLabel({label: (
+        await messenger.browserAction.setLabel({label: (
           preferences.showStatus ? messenger.i18n.getMessage("sendlater3header.label") : ""
         )});
 
@@ -1365,8 +1365,8 @@ async function mainLoop() {
       // or (⌛ \u231B) (e.g. badgeText = "\u27F3")
       let extName = messenger.i18n.getMessage("extensionName");
       let isActiveMessage = messenger.i18n.getMessage("CheckingMessage");
-      messenger.browserAction.enable();
-      messenger.browserAction.setTitle({title: `${extName} [${isActiveMessage}]`});
+      await messenger.browserAction.enable();
+      await messenger.browserAction.setTitle({title: `${extName} [${isActiveMessage}]`});
 
       let doSequential = preferences.throttleDelay > 0;
       console.debug({doSequential, throttleDelay: preferences.throttleDelay});
@@ -1394,9 +1394,10 @@ async function mainLoop() {
       SendLater.setQuitNotificationsEnabled(false);
       let extName = messenger.i18n.getMessage("extensionName");
       let disabledMsg = messenger.i18n.getMessage("DisabledMessage");
-      messenger.browserAction.disable();
-      messenger.browserAction.setTitle({title: `${extName} [${disabledMsg}]`});
-      messenger.browserAction.setBadgeText({text: null});
+      await messenger.browserAction.disable();
+      await messenger.browserAction.setTitle(
+        {title: `${extName} [${disabledMsg}]`});
+      await messenger.browserAction.setBadgeText({text: null});
 
       SendLater.previousLoop = new Date();
       SendLater.loopTimeout = setTimeout(mainLoop, 60000);

--- a/background.js
+++ b/background.js
@@ -801,7 +801,7 @@ const SendLater = {
       messenger.storage.onChanged.addListener(SendLater.storageChangedListener);
     },
 
-    storageChangedListener(changes, areaName) {
+    async storageChangedListener(changes, areaName) {
       if (areaName === "local" && changes.preferences) {
         SLStatic.debug("Propagating changes from local storage");
         const preferences = changes.preferences.newValue;
@@ -818,7 +818,7 @@ const SendLater = {
 
         messenger.SL3U.setLogConsoleLevel(SLStatic.logConsoleLevel);
 
-        SendLater.setQuitNotificationsEnabled(preferences.askQuit);
+        await SendLater.setQuitNotificationsEnabled(preferences.askQuit);
 
         await messenger.browserAction.setLabel({label: (
           preferences.showStatus ? messenger.i18n.getMessage("sendlater3header.label") : ""
@@ -918,7 +918,7 @@ const SendLater = {
           // The new message is not used.
           // console.debug({originalMsg, newMsg});
 
-          SendLater.updateStatusIndicator();
+          await SendLater.updateStatusIndicator();
     
           // Set popup scheduler defaults based on original message
           scheduleCache[window.id] =
@@ -1374,8 +1374,9 @@ async function mainLoop() {
       try {
         await SLTools.forAllDrafts(SendLater.possiblySendMessage, doSequential)
         let nActive = await SLTools.countActiveScheduledMessages();
-        SendLater.updateStatusIndicator(nActive);
-        SendLater.setQuitNotificationsEnabled(preferences.askQuit, nActive);
+        await SendLater.updateStatusIndicator(nActive);
+        await SendLater.setQuitNotificationsEnabled(
+          preferences.askQuit, nActive);
 
         SendLater.previousLoop = new Date();
         SendLater.loopTimeout = setTimeout(mainLoop, 60000*interval);
@@ -1383,15 +1384,16 @@ async function mainLoop() {
       } catch(err) {
         SLStatic.error(err);
         let nActive = await SLTools.countActiveScheduledMessages();
-        SendLater.updateStatusIndicator(nActive);
-        SendLater.setQuitNotificationsEnabled(preferences.askQuit, nActive);
+        await SendLater.updateStatusIndicator(nActive);
+        await SendLater.setQuitNotificationsEnabled(
+          preferences.askQuit, nActive);
         
         SendLater.previousLoop = new Date();
         SendLater.loopTimeout = setTimeout(mainLoop, 60000);
         SLStatic.debug(`Next main loop iteration in 1 minute.`);
       };
     } else {
-      SendLater.setQuitNotificationsEnabled(false);
+      await SendLater.setQuitNotificationsEnabled(false);
       let extName = messenger.i18n.getMessage("extensionName");
       let disabledMsg = messenger.i18n.getMessage("DisabledMessage");
       await messenger.browserAction.disable();

--- a/background.js
+++ b/background.js
@@ -1314,30 +1314,30 @@ const SendLater = {
     // visible, but they will be disabled and show a message indicating that the extension is
     // disabled. This is important for cases where the extension failed to fully intialize, so
     // that the user doesn't get a false impression that the extension is working.
-    disable() {
+    async disable() {
       SLStatic.warn("Disabling Send Later.");
-      SLStatic.nofail(clearTimeout, SendLater.loopTimeout);
-      SLStatic.nofail(SendLater.setQuitNotificationsEnabled, false);
-      SLStatic.nofail(messenger.browserAction.disable);
-      SLStatic.nofail(messenger.browserAction.setTitle, {
+      await SLStatic.nofail(clearTimeout, SendLater.loopTimeout);
+      await SLStatic.nofail(SendLater.setQuitNotificationsEnabled, false);
+      await SLStatic.nofail(messenger.browserAction.disable);
+      await SLStatic.nofail(messenger.browserAction.setTitle, {
         title: `${messenger.i18n.getMessage("extensionName")} [${messenger.i18n.getMessage("DisabledMessage")}]`
       });
-      SLStatic.nofail(messenger.browserAction.setBadgeText, {text: null});
-      SLStatic.nofail(messenger.composeAction.disable);
-      SLStatic.nofail(messenger.composeAction.setPopup, {"popup": null});
-      SLStatic.nofail(messenger.messageDisplayAction.disable);
-      SLStatic.nofail(messenger.messageDisplayAction.setPopup, {"popup": null});
-      SLStatic.nofail(messenger.windows.onCreated.removeListener, SendLater.onWindowCreatedListener);
-      SLStatic.nofail(messenger.SL3U.onKeyCode.removeListener, SendLater.onUserCommandKeyListener);
-      SLStatic.nofail(messenger.runtime.onMessageExternal.removeListener, SendLater.onMessageExternalListener);
-      SLStatic.nofail(messenger.runtime.onMessage.removeListener, SendLater.onRuntimeMessageListenerasync);
-      SLStatic.nofail(messenger.messages.onNewMailReceived.removeListener, SendLater.onNewMailReceivedListener);
-      SLStatic.nofail(messenger.messageDisplay.onMessageDisplayed.removeListener, SendLater.onMessageDisplayedListener);
-      SLStatic.nofail(messenger.commands.onCommand.removeListener, SendLater.onCommandListener);
-      SLStatic.nofail(messenger.composeAction.onClicked.removeListener, SendLater.clickComposeListener);
-      SLStatic.nofail(messenger.mailTabs.onDisplayedFolderChanged.removeListener, SendLater.displayedFolderChangedListener);
-      SLStatic.nofail(messenger.headerView.onHeaderRowUpdate.removeListener, SendLater.headerRowUpdateListener);
-      SLStatic.nofail(messenger.storage.onChanged.removeListener, SendLater.storageChangedListener);
+      await SLStatic.nofail(messenger.browserAction.setBadgeText, {text: null});
+      await SLStatic.nofail(messenger.composeAction.disable);
+      await SLStatic.nofail(messenger.composeAction.setPopup, {"popup": null});
+      await SLStatic.nofail(messenger.messageDisplayAction.disable);
+      await SLStatic.nofail(messenger.messageDisplayAction.setPopup, {"popup": null});
+      await SLStatic.nofail(messenger.windows.onCreated.removeListener, SendLater.onWindowCreatedListener);
+      await SLStatic.nofail(messenger.SL3U.onKeyCode.removeListener, SendLater.onUserCommandKeyListener);
+      await SLStatic.nofail(messenger.runtime.onMessageExternal.removeListener, SendLater.onMessageExternalListener);
+      await SLStatic.nofail(messenger.runtime.onMessage.removeListener, SendLater.onRuntimeMessageListenerasync);
+      await SLStatic.nofail(messenger.messages.onNewMailReceived.removeListener, SendLater.onNewMailReceivedListener);
+      await SLStatic.nofail(messenger.messageDisplay.onMessageDisplayed.removeListener, SendLater.onMessageDisplayedListener);
+      await SLStatic.nofail(messenger.commands.onCommand.removeListener, SendLater.onCommandListener);
+      await SLStatic.nofail(messenger.composeAction.onClicked.removeListener, SendLater.clickComposeListener);
+      await SLStatic.nofail(messenger.mailTabs.onDisplayedFolderChanged.removeListener, SendLater.displayedFolderChangedListener);
+      await SLStatic.nofail(messenger.headerView.onHeaderRowUpdate.removeListener, SendLater.headerRowUpdateListener);
+      await SLStatic.nofail(messenger.storage.onChanged.removeListener, SendLater.storageChangedListener);
       SLStatic.warn("Disabled.");
     }
 

--- a/background.js
+++ b/background.js
@@ -39,7 +39,7 @@ const SendLater = {
           return;
         }
       }
-      messenger.compose.sendMessage(tabId, {mode: "sendNow"});
+      await messenger.compose.sendMessage(tabId, {mode: "sendNow"});
     },
 
     // Use built-in send later function (after some pre-send checks)
@@ -945,7 +945,7 @@ const SendLater = {
     // composition windows. These events occur when the user activates
     // the built-in send or send later using either key combinations
     // (e.g. ctrl+shift+enter), or click the file menu buttons.
-    onUserCommandKeyListener(keyid) {
+    async onUserCommandKeyListener(keyid) {
       SLStatic.info(`Received keycode ${keyid}`);
       switch (keyid) {
         case "key_altShiftEnter": {
@@ -963,14 +963,11 @@ const SendLater = {
             if (SendLater.prefCache.altBinding) {
               SLStatic.info("Passing Ctrl+Shift+Enter along to builtin send later " +
                             "because user bound alt+shift+enter instead.");
-              // TODO: Undesired use of a not-awaited .then() callback in an event
-              // handler. It is true that there is no code executed after this so
-              // technically it does not need to be awaited, but consistently using
-              // async/await helps to improve maintainability.
-              SLTools.getActiveComposeTab().then(curTab => {
-                if (curTab)
-                  messenger.compose.sendMessage(curTab.id, {mode: "sendLater"});
-              });
+              let curTab = await SLTools.getActiveComposeTab();
+              if (curTab) {
+                await messenger.compose.sendMessage(
+                  curTab.id, {mode: "sendLater"});
+              }
             } else {
               SLStatic.info("Opening popup");
               messenger.composeAction.openPopup();
@@ -994,23 +991,17 @@ const SendLater = {
               // Schedule with delay.
               const sendDelay = SendLater.prefCache.sendDelay;
               SLStatic.info(`Scheduling Send Later ${sendDelay} minutes from now.`);
-              // TODO: Undesired use of a not-awaited .then() callback in an event
-              // handler. It is true that there is no code executed after this so
-              // technically it does not need to be awaited, but consistently using
-              // async/await helps to improve maintainability.
-              SLTools.getActiveComposeTab().then(curTab => {
-                if (curTab)
-                  SendLater.scheduleSendLater(curTab.id, {delay: sendDelay});
-              });
+              let curTab = await SLTools.getActiveComposeTab();
+              if (curTab) {
+                await SendLater.scheduleSendLater(
+                  curTab.id, {delay: sendDelay});
+              }
             } else {
-              // TODO: Undesired use of a not-awaited .then() callback in an event
-              // handler. It is true that there is no code executed after this so
-              // technically it does not need to be awaited, but consistently using
-              // async/await helps to improve maintainability.
-              SLTools.getActiveComposeTab().then(curTab => {
-                if (curTab)
-                  messenger.compose.sendMessage(curTab.id, {mode: "sendNow"});
-              });
+              let curTab = await SLTools.getActiveComposeTab();
+              if (curTab) {
+                await messenger.compose.sendMessage(
+                  curTab.id, {mode: "sendNow"});
+              }
             }
             break;
           }

--- a/background.js
+++ b/background.js
@@ -186,12 +186,12 @@ const SendLater = {
       // to show that it has been replied to or forwarded.
       if (composeDetails.relatedMessageId) {
         if (composeDetails.type == "reply") {
-          console.debug("This is a reply message. Setting original 'replied'");
+          SLStatic.debug("This is a reply message. Setting original 'replied'");
           await messenger.SL3U.setDispositionState(
             composeDetails.relatedMessageId, "replied"
           );
         } else if (composeDetails.type == "forward") {
-          console.debug("This is a fwd message. Setting original 'forwarded'");
+          SLStatic.debug("This is a fwd message. Setting original 'forwarded'");
           await messenger.SL3U.setDispositionState(
             composeDetails.relatedMessageId, "forwarded"
           );
@@ -1199,7 +1199,8 @@ const SendLater = {
           response.schedules = await SLTools.forAllDrafts(
             async (draftHdr) => {
               if (SLTools.unscheduledMsgCache.has(draftHdr.id)) {
-                console.debug("Ignoring unscheduled message", draftHdr.id, draftHdr);
+                SLStatic.debug(
+                  "Ignoring unscheduled message", draftHdr.id, draftHdr);
                 return null;
               }
               return await messenger.messages.getFull(draftHdr.id).then(
@@ -1402,7 +1403,6 @@ async function mainLoop() {
       await messenger.browserAction.setTitle({title: `${extName} [${isActiveMessage}]`});
 
       let doSequential = preferences.throttleDelay > 0;
-      console.debug({doSequential, throttleDelay: preferences.throttleDelay});
 
       try {
         await SLTools.forAllDrafts(SendLater.possiblySendMessage, doSequential)

--- a/background.js
+++ b/background.js
@@ -1271,7 +1271,7 @@ const SendLater = {
         const instanceUUID = preferences.instanceUUID;
         let msg = await messenger.messages.getFull(hdr.id);
         if (msg.headers["x-send-later-uuid"] == instanceUUID) {
-          messenger.messageDisplayAction.enable(tab.id);
+          await messenger.messageDisplayAction.enable(tab.id);
         }
       } else {
         SLStatic.debug("This is not a Drafts folder, so Send Later will not scan it.");

--- a/background.js
+++ b/background.js
@@ -739,9 +739,16 @@ const SendLater = {
       // We won't get events for tabs that are already loaded.
       SendLater.configureAllTabs();
 
+      // Initialize expanded header row
+      await messenger.headerView.addCustomHdrRow({
+        name: messenger.i18n.getMessage("sendlater3header.label"),
+      }).catch(ex => {
+        SLStatic.error("headerView.addCustomHdrRow",ex);
+      });
       messenger.headerView.onHeaderRowUpdate.addListener(
         SendLater.headerRowUpdateListener, messenger.i18n.getMessage("sendlater3header.label")
       );
+
       messenger.messages.onNewMailReceived.addListener(SendLater.onNewMailReceivedListener);
 
       // Set custom DB headers preference, if not already set.
@@ -787,13 +794,6 @@ const SendLater = {
       } catch (ex) {
         SLStatic.error(ex);
       }
-
-      // Initialize expanded header row
-      await messenger.headerView.addCustomHdrRow({
-        name: messenger.i18n.getMessage("sendlater3header.label"),
-      }).catch(ex => {
-        SLStatic.error("headerView.addCustomHdrRow",ex);
-      });
 
       // Attach to all existing msgcompose windows
       messenger.SL3U.hijackComposeWindowKeyBindings().catch(ex => {

--- a/background.js
+++ b/background.js
@@ -1023,11 +1023,13 @@ const SendLater = {
     onMessageExternalListener(message, sender, sendResponse) {
       switch (message.action) {
         case "getUUID": {
+          // Return Promise for the instanceUUID.
           return SLTools.getPrefs()
             .then(preferences => preferences.instanceUUID)
             .catch(ex => SLStatic.error(ex));
         }
         case "getPreferences": {
+          // Return Promise for the allowed preferences.
           return SLTools.getPrefs()
             .then(preferences => preferences.filter(prop => SLStatic.prefInputIds.includes(prop)))
             .catch(ex => SLStatic.error(ex));
@@ -1053,11 +1055,15 @@ const SendLater = {
             await messenger.storage.local.set({preferences: old_prefs});
             return old_prefs;
           }
+          // Return Promise for updating the allowed preferences.
           return SLTools.getPrefs()
             .then(old_prefs => setAndReturnPrefs(old_prefs, message.preferences))
             .catch(ex => SLStatic.error(ex));
         }
         case "parseDate": {
+          // Return Promise for the Date. Since this is a sync operation, the
+          // Promise is already fulfilled. But it still has to be a Promise, or
+          // sendResponse() has to be used instead. Promise syntax is preferred.
           try {
             const date = SLStatic.convertDate(message["value"]);
             if (date) {

--- a/utils/static.js
+++ b/utils/static.js
@@ -70,11 +70,12 @@ var SLStatic = {
 
   // Run a function and report any errors to the console, but don't let the error
   // propagate to the caller.
-  nofail(func, ...args) {
-    if (func[Symbol.toStringTag] === "AsyncFunction") {
-      func(...args).catch(console.error);
-    } else {
-      try { func(...args) } catch (e) { console.error(e) }
+  async nofail(func, ...args) {
+    try {
+      await func(...args);
+    }
+    catch (e) {
+      console.error(e);
     }
   },
 

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -135,7 +135,7 @@ var SLTools = {
       let draftFolders = SLTools.getDraftFolders(acct);
       for (let folder of draftFolders) {
         let page = await messenger.messages.list(folder);
-        do {
+        while (true) {
           if (sequential) {
             for (let message of page.messages) {
               results.push(await callback(message).catch(SLStatic.error));
@@ -146,10 +146,11 @@ var SLTools = {
             );
             results = results.concat(pageResults);
           }
-          if (page.id) {
-            page = await messenger.messages.continueList(page.id);
+          if (!page.id) {
+            break;
           }
-        } while (page.id);
+          page = await messenger.messages.continueList(page.id);
+        }
       }
     }
     if (sequential) {


### PR DESCRIPTION
This tries to deal with the symptoms described on #554.

We need to make sure that `.then()` callbacks do not spin into their own thread and are not part of the expected execution flow.

It is valid and sometimes more readable syntax to mix await and .`then()` and I did not remove all of them, but the Promise chain needs to be awaited. I did remove some wrongly nested chains.

I added comments, where I think code could be improved further.

