### PR TITLE
Restore execution order related to compactDrafts()

### DIFF
--- a/background.js
+++ b/background.js
@@ -488,13 +488,12 @@ const SendLater = {
       // This _may_ be fixed in TB129, so we may eventually be able to remove
       // the delay, but possibly not if the root cause can't be identified. See
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1909111 .
-      setTimeout(async () => {
-        for (let folder of SendLater.draftsToCompact) {
-          SLStatic.debug("Compacting folder:", folder);
-          await messenger.SL3U.compactFolder(folder);
-        }
-        SendLater.draftsToCompact.length = 0;
-      }, 1000);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      for (let folder of SendLater.draftsToCompact) {
+        SLStatic.debug("Compacting folder:", folder);
+        await messenger.SL3U.compactFolder(folder);
+      }
+      SendLater.draftsToCompact.length = 0;
     } else if (SendLater.draftsToCompact.length) {
       SLStatic.debug("Not compacting folders, preference is disabled");
       SendLater.draftsToCompact.length = 0;


### PR DESCRIPTION
Commit https://github.com/Extended-Thunder/send-later/commit/fd3d19bab2f0bb945747b4d211f6e6356e5fa7bb introduced a delay to mitigate Bug 1909111.

The change adds a delay before compacting, which resolves the error reported to this project, which is primarily caused by the mentioned underlying Thunderbird bug.

That commit changed the execution flow: The used `setTimeout()` causes the Promise returned by `compactDrafts()` to resolve before the compacting has started. This is a change in behaviour which could have unwanted side effects. There are multiple calls to `await compactDrafts()` which assume that any code executed after calling `await compactDrafts()` is executed after compacting has finished.

This PR suggests keeping the 1s delay to mitigate Bug 1909111, but make the Promise returned by `compactDrafts()` resolve after the additional delay and after compacting the folder has finished, restoring the original execution flow and keeping the 1s delay to mitigate Thunderbird Bug 1909111.