### PR TITLE
use getWeekInfo() instead of weekInfo

### DIFF
--- a/utils/sugar-custom.js
+++ b/utils/sugar-custom.js
@@ -3592,7 +3592,7 @@
       let shortTime = Intl.DateTimeFormat(localeString, {
         timeStyle: "short",
       }).format(date);
-      let weekInfo = new Intl.Locale(localeString).weekInfo;
+      let weekInfo = new Intl.Locale(localeString).getWeekInfo();
       if (weekInfo) {
         if ([0, 7].includes(weekInfo.firstDay)) {
           variant.firstDayOfWeek = 0;


### PR DESCRIPTION
weekInfo is changed to getWeekInfo() in https://tc39.es/proposal-intl-locale-info/

See tc39/proposal-intl-locale-info#67