### PR TITLE
Fix identity resolution: trust X-Identity-Key with email match

### DIFF
--- a/background.js
+++ b/background.js
@@ -3063,7 +3063,16 @@ async function findBestIdentity(message, messageFull) {
   let keyIdentityId = messageFull?.headers["x-identity-key"]?.at(0);
   if (keyIdentityId) {
     let keyIdentity = await messenger.identities.get(keyIdentityId);
-    if (keyIdentity && exactIdentityMatch(author, keyIdentity))
+    // Trust X-Identity-Key if the identity exists and the email address
+    // matches. This header was set by Thunderbird's compose system when
+    // the user scheduled the message, so it reflects the user's intent.
+    // Using exactIdentityMatch here is too strict — it fails when the
+    // From header has different formatting (RFC 2047 encoding, quoting,
+    // whitespace) than identity.name + " <" + identity.email + ">",
+    // causing the authoritative identity key to be discarded and the
+    // wrong identity to be selected via the fallback cascade.
+    // See: https://github.com/Extended-Thunder/send-later/issues/781
+    if (keyIdentity && emailIdentityMatch(author, keyIdentity))
       return keyIdentity;
   }
   let account = await messenger.accounts.get(message.folder.accountId, false);

--- a/background.js
+++ b/background.js
@@ -3063,16 +3063,21 @@ async function findBestIdentity(message, messageFull) {
   let keyIdentityId = messageFull?.headers["x-identity-key"]?.at(0);
   if (keyIdentityId) {
     let keyIdentity = await messenger.identities.get(keyIdentityId);
-    // Trust X-Identity-Key if the identity exists and the email address
-    // matches. This header was set by Thunderbird's compose system when
-    // the user scheduled the message, so it reflects the user's intent.
-    // Using exactIdentityMatch here is too strict — it fails when the
-    // From header has different formatting (RFC 2047 encoding, quoting,
-    // whitespace) than identity.name + " <" + identity.email + ">",
-    // causing the authoritative identity key to be discarded and the
-    // wrong identity to be selected via the fallback cascade.
-    // See: https://github.com/Extended-Thunder/send-later/issues/781
-    if (keyIdentity && emailIdentityMatch(author, keyIdentity))
+    if (keyIdentity) {
+      let expected = keyIdentity.name
+        ? `${keyIdentity.name} <${keyIdentity.email}>`
+        : keyIdentity.email;
+      SLTools.info("findBestIdentity: X-Identity-Key lookup", {
+        keyIdentityId,
+        author: JSON.stringify(author),
+        expected: JSON.stringify(expected),
+        identityName: JSON.stringify(keyIdentity.name),
+        identityEmail: JSON.stringify(keyIdentity.email),
+        exactMatch: exactIdentityMatch(author, keyIdentity),
+        emailMatch: emailIdentityMatch(author, keyIdentity),
+      });
+    }
+    if (keyIdentity && exactIdentityMatch(author, keyIdentity))
       return keyIdentity;
   }
   let account = await messenger.accounts.get(message.folder.accountId, false);


### PR DESCRIPTION
## Summary

Fix for #781 — wrong SMTP server (and potentially wrong From display name) when using alternate identities.

- Relaxes the `X-Identity-Key` guard in `findBestIdentity()` from `exactIdentityMatch` to `emailIdentityMatch`
- The `X-Identity-Key` header is set by Thunderbird's compose system at scheduling time and represents the user's explicit identity choice — it should be trusted as long as the email address matches
- `exactIdentityMatch` requires the From header to be exactly `"Display Name <email>"`, which fails on formatting differences (RFC 2047 encoding, quoting, whitespace), causing the authoritative identity key to be silently discarded

## Problem

When scheduling a message with an alternate identity, `findBestIdentity()` discards the correct `X-Identity-Key` if the From header string doesn't exactly match `identity.name + " <" + identity.email + ">"`. The function then falls through to a cascade of looser matching functions that may select the wrong identity, resulting in:

- Wrong SMTP server used for delivery
- Missing or wrong From display name

This particularly affects setups with multiple identities sharing the same email address, or identities with display names that get re-encoded between compose and draft storage.

## Fix

One-line change: replace `exactIdentityMatch` with `emailIdentityMatch` in the `X-Identity-Key` guard (line 3066). This verifies the email address matches while tolerating formatting differences in the display name.

## Test plan

- [ ] Schedule a message with an alternate identity that has a different SMTP server
- [ ] Verify the correct SMTP server is used at delivery time
- [ ] Schedule a message with an identity that shares an email address with another identity but has a different display name
- [ ] Verify the correct display name appears in the sent message

Fixes #781